### PR TITLE
Fancy tracebacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3.8-distutils \
     gcc \
     postgresql-client-12 \
+    git \
     libpq-dev
 
 RUN ln -s /usr/bin/python3.8 /usr/local/bin/python

--- a/backend/main/chapters/c01_the_shell.py
+++ b/backend/main/chapters/c01_the_shell.py
@@ -1,5 +1,8 @@
 # flake8: NOQA E501
-from main.text import MessageStep, Page, Step, VerbatimStep
+import ast
+from textwrap import dedent
+
+from main.text import MessageStep, Page, Step, VerbatimStep, search_ast
 
 
 class IntroducingTheShell(Page):
@@ -37,20 +40,20 @@ Try doing some more calculations now. You can multiply numbers with `*`, divide 
 
         program = "5 - 6"
 
-        class x_to_multiple(MessageStep):
-            """
+        def check(self):
+            try:
+                return search_ast(self.stmt, (ast.Mult, ast.Div, ast.Sub))
+            except SyntaxError:
+                if "x" in self.input:
+                    return dict(
+                        message=dedent(
+                            """
             I see an 'x'. If you're trying to multiply, use an asterisk, e.g:
 
                 3 * 4
             """
-
-            program = "3 x 4"
-
-            def check(self):
-                return "x" in self.input
-
-        def check(self):
-            return self.input_matches(r"\d[-*/]\d")
+                        )
+                    )
 
     final_text = """
 Excellent! Keep experimenting. When you're ready, click 'Next' to continue.

--- a/backend/main/chapters/c01_the_shell.py
+++ b/backend/main/chapters/c01_the_shell.py
@@ -5,7 +5,7 @@ from main.text import MessageStep, Page, Step, VerbatimStep
 class IntroducingTheShell(Page):
     class first_expression(VerbatimStep):
         """
-At the bottom right of the screen is the *shell*. This is a place for running small bits of Python code. Just type in some code, press enter, and it'll run! Try it now:
+On the right is the *shell*. This is a place for running small bits of Python code. Just type in some code, press enter, and it'll run! Try it now:
 
 1. Click anywhere on the shell (the black area).
 2. Type `__program__`

--- a/backend/main/chapters/c07_nested_loops.py
+++ b/backend/main/chapters/c07_nested_loops.py
@@ -124,6 +124,19 @@ Make sure each line is in the correct loop and has the right amount of indentati
 
         parsons_solution = True
 
+        def check(self):
+            try:
+                return super().check()
+            except SyntaxError:
+                lines = self.result.splitlines()
+                if (
+                    len(lines) >= 3
+                    and lines[2].strip() == "SyntaxError: invalid syntax"
+                    and lines[1].strip() == "^"
+                    and lines[0][lines[1].index("^")] == "x"
+                ):
+                    return dict(message="To multiply numbers, use `*`")
+
         def solution(self):
             for left in range(12):
                 left += 1
@@ -176,29 +189,6 @@ as shown above, e.g. `print(x, y, z)`. It'll even add spaces for you!
 
             def check(self):
                 return "TypeError: unsupported operand type(s) for +: " in self.result
-
-        class used_x_to_multiply(MessageStep):
-            """To multiply numbers, use `*`"""
-
-            program = "2 x 3"
-
-            def check(self):
-                """
-                Check for a traceback like:
-                    2 x 3
-                      ^
-                SyntaxError: invalid syntax
-
-                It might be better to try replacing x with * and see if
-                it becomes valid syntax
-                """
-                lines = self.result.strip().splitlines()
-                return (
-                        len(lines) >= 3 and
-                        lines[-1] == "SyntaxError: invalid syntax" and
-                        lines[-2].strip() == "^" and
-                        lines[-3][lines[-2].index("^")] == "x"
-                )
 
         tests = {
             (): """\

--- a/backend/main/test_transcript.json
+++ b/backend/main/test_transcript.json
@@ -2510,7 +2510,7 @@
                                     ]
                                 }
                             ],
-                            "friendly": "<p>A <code>NameError</code> exception indicates that a variable or\nfunction name is not known to Python.\nMost often, this is because there is a spelling mistake.\nHowever, sometimes it is because the name is used\nbefore being defined or given a value.</p>\n<p>In your program, the unknown name is <code>char</code>.\nThe Python builtin <code>'chr'</code> has a similar name. </p>",
+                            "friendly": "<p>A <code>NameError</code> exception indicates that a variable or\nfunction name is not known to Python.\nMost often, this is because there is a spelling mistake.\nHowever, sometimes it is because the name is used\nbefore being defined or given a value.</p>\n<p>In your program, the unknown name is <code>char</code>.\nThe Python builtin <code>chr</code> has a similar name. </p>",
                             "tail": ""
                         }
                     ]

--- a/backend/main/test_transcript.json
+++ b/backend/main/test_transcript.json
@@ -60,23 +60,11 @@
             "result": [
                 {
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
+                    "text": "    3 x 4\n      ^\nSyntaxError: invalid syntax\nat line 1\n\nA `SyntaxError` occurs when Python cannot understand your code.\n\nCurrently, I cannot guess the likely cause of this error.\nTry to examine closely the line indicated as well as the line\nimmediately above to see if you can identify some misspelled\nword, or missing symbols, like (, ), [, ], :, etc.\n\nYou might want to report this case to\nhttps://github.com/aroberge/friendly-traceback/issues\n\n"
                 },
                 {
                     "color": "red",
-                    "text": "  File \"my_program.py\", line 1\n"
-                },
-                {
-                    "color": "red",
-                    "text": "    3 x 4\n"
-                },
-                {
-                    "color": "red",
-                    "text": "      ^\n"
-                },
-                {
-                    "color": "red",
-                    "text": "SyntaxError: invalid syntax\n"
+                    "text": "\n"
                 },
                 {
                     "color": "white",
@@ -311,20 +299,36 @@
             },
             "result": [
                 {
+                    "codeSource": "shell",
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": " File \"my_program.py\", line 1, in <module>\n"
-                },
-                {
-                    "color": "red",
-                    "text": "-->    1 | \u001b[38;5;15msunshine\u001b[39m\n"
-                },
-                {
-                    "color": "red",
-                    "text": "NameError: name 'sunshine' is not defined\n"
+                    "isTraceback": true,
+                    "text": "NameError: name 'sunshine' is not defined",
+                    "tracebacks": [
+                        {
+                            "didyoumean": [],
+                            "exception": {
+                                "message": "name 'sunshine' is not defined",
+                                "type": "NameError"
+                            },
+                            "frames": [
+                                {
+                                    "lines": [
+                                        {
+                                            "content": "<span class=\"n\">sunshine</span>",
+                                            "is_current": true,
+                                            "lineno": 1,
+                                            "type": "line"
+                                        }
+                                    ],
+                                    "name": "<module>",
+                                    "type": "frame",
+                                    "variables": []
+                                }
+                            ],
+                            "friendly": "<p>A <code>NameError</code> exception indicates that a variable or\nfunction name is not known to Python.\nMost often, this is because there is a spelling mistake.\nHowever, sometimes it is because the name is used\nbefore being defined or given a value.</p>",
+                            "tail": ""
+                        }
+                    ]
                 },
                 {
                     "color": "white",
@@ -758,23 +762,11 @@
             "result": [
                 {
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
+                    "text": "    print(character)\n    ^\nIndentationError: expected an indented block\nat line 2\n\nAn `IndentationError` occurs when a given line of code is\nnot indented (aligned vertically with other lines) as expected.\n\nIn this case, the line identified above\nwas expected to begin a new indented block.\n"
                 },
                 {
                     "color": "red",
-                    "text": "  File \"my_program.py\", line 2\n"
-                },
-                {
-                    "color": "red",
-                    "text": "    print(character)\n"
-                },
-                {
-                    "color": "red",
-                    "text": "    ^\n"
-                },
-                {
-                    "color": "red",
-                    "text": "IndentationError: expected an indented block\n"
+                    "text": "\n"
                 },
                 {
                     "color": "white",
@@ -967,23 +959,11 @@
             "result": [
                 {
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
+                    "text": "    print('---')\n               ^\nIndentationError: unindent does not match any outer indentation level\nat line 3\n\nAn `IndentationError` occurs when a given line of code is\nnot indented (aligned vertically with other lines) as expected.\n\nIn this case, the line identified above is\nless indented than the preceding one,\nand is not aligned vertically with another block of code.\n"
                 },
                 {
                     "color": "red",
-                    "text": "  File \"my_program.py\", line 3\n"
-                },
-                {
-                    "color": "red",
-                    "text": "    print('---')\n"
-                },
-                {
-                    "color": "red",
-                    "text": "               ^\n"
-                },
-                {
-                    "color": "red",
-                    "text": "IndentationError: unindent does not match any outer indentation level\n"
+                    "text": "\n"
                 },
                 {
                     "color": "white",
@@ -2493,20 +2473,47 @@
             },
             "result": [
                 {
+                    "codeSource": "editor",
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": " File \"my_program.py\", line 6, in <module>\n"
-                },
-                {
-                    "color": "red",
-                    "text": "-->    6 | \u001b[38;5;15msentence\u001b[39m\u001b[38;5;15m \u001b[39m\u001b[38;5;197m+\u001b[39m\u001b[38;5;197m=\u001b[39m\u001b[38;5;15m \u001b[39m\u001b[38;5;15mchar\u001b[39m\n"
-                },
-                {
-                    "color": "red",
-                    "text": "NameError: name 'char' is not defined\n"
+                    "isTraceback": true,
+                    "text": "NameError: name 'char' is not defined",
+                    "tracebacks": [
+                        {
+                            "didyoumean": [
+                                "'chr' (builtin)"
+                            ],
+                            "exception": {
+                                "message": "name 'char' is not defined",
+                                "type": "NameError"
+                            },
+                            "frames": [
+                                {
+                                    "lines": [
+                                        {
+                                            "content": "<span class=\"n\">sentence</span> <span class=\"o\">+=</span> <span class=\"n\">char</span>",
+                                            "is_current": true,
+                                            "lineno": 6,
+                                            "type": "line"
+                                        }
+                                    ],
+                                    "name": "<module>",
+                                    "type": "frame",
+                                    "variables": [
+                                        {
+                                            "name": "<span class=\"n\">excited</span>\n",
+                                            "value": "<span class=\"kc\">False</span>\n"
+                                        },
+                                        {
+                                            "name": "<span class=\"n\">sentence</span>\n",
+                                            "value": "<span class=\"s1\">&#39;Hello World&#39;</span>\n"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "friendly": "<p>A <code>NameError</code> exception indicates that a variable or\nfunction name is not known to Python.\nMost often, this is because there is a spelling mistake.\nHowever, sometimes it is because the name is used\nbefore being defined or given a value.</p>",
+                            "tail": ""
+                        }
+                    ]
                 },
                 {
                     "color": "white",
@@ -2703,15 +2710,11 @@
             "result": [
                 {
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
+                    "text": "SyntaxError: expression cannot contain assignment, perhaps you meant \"==\"?\nat line 1\n\nA `SyntaxError` occurs when Python cannot understand your code.\n\nOne of the following two possibilities could be the cause:\n1. You meant to do a comparison with == and wrote = instead.\n2. You called a function with a named argument:\n\n       a_function(invalid=something)\n\nwhere `invalid` is not a valid variable name in Python\neither because it starts with a number, or is a string,\nor contains a period, etc.\n\n"
                 },
                 {
                     "color": "red",
-                    "text": "  File \"my_program.py\", line 1\n"
-                },
-                {
-                    "color": "red",
-                    "text": "SyntaxError: expression cannot contain assignment, perhaps you meant \"==\"?\n"
+                    "text": "\n"
                 },
                 {
                     "color": "white",
@@ -3508,20 +3511,41 @@
             "passed": true,
             "result": [
                 {
+                    "codeSource": "shell",
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": " File \"my_program.py\", line 1, in <module>\n"
-                },
-                {
-                    "color": "red",
-                    "text": "-->    1 | \u001b[38;5;15mwords\u001b[39m\u001b[38;5;15m[\u001b[39m\u001b[38;5;141m4\u001b[39m\u001b[38;5;15m]\u001b[39m\n"
-                },
-                {
-                    "color": "red",
-                    "text": "IndexError: list index out of range\n"
+                    "isTraceback": true,
+                    "text": "IndexError: list index out of range",
+                    "tracebacks": [
+                        {
+                            "didyoumean": [],
+                            "exception": {
+                                "message": "list index out of range",
+                                "type": "IndexError"
+                            },
+                            "frames": [
+                                {
+                                    "lines": [
+                                        {
+                                            "content": "<span class=\"n\">words</span><span class=\"p\">[</span><span class=\"mi\">4</span><span class=\"p\">]</span>",
+                                            "is_current": true,
+                                            "lineno": 1,
+                                            "type": "line"
+                                        }
+                                    ],
+                                    "name": "<module>",
+                                    "type": "frame",
+                                    "variables": [
+                                        {
+                                            "name": "<span class=\"n\">words</span>\n",
+                                            "value": "<span class=\"p\">[</span><span class=\"s1\">&#39;This&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;is&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;a&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;list&#39;</span><span class=\"p\">]</span>\n"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "friendly": "<p>An <code>IndexError</code> occurs when you are try to get an item from a list,\na tuple, or a similar object (sequence), by using an index which\ndoes not exists; typically, this is because the index you give\nis greater than the length of the sequence.\nReminder: the first item of a sequence is at index 0.</p>",
+                            "tail": ""
+                        }
+                    ]
                 },
                 {
                     "color": "white",
@@ -4093,20 +4117,43 @@
                     "text": "\n"
                 },
                 {
+                    "codeSource": "editor",
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": " File \"my_program.py\", line 3, in <module>\n"
-                },
-                {
-                    "color": "red",
-                    "text": "-->    3 | \u001b[38;5;15;48;5;24mf\u001b[39;49m\u001b[38;5;15;48;5;24m(\u001b[39;49m\u001b[38;5;15;48;5;24m)\u001b[39;49m\n"
-                },
-                {
-                    "color": "red",
-                    "text": "TypeError: 'str' object is not callable\n"
+                    "isTraceback": true,
+                    "text": "TypeError: 'str' object is not callable",
+                    "tracebacks": [
+                        {
+                            "didyoumean": [
+                                "'str[value]'"
+                            ],
+                            "exception": {
+                                "message": "'str' object is not callable",
+                                "type": "TypeError"
+                            },
+                            "frames": [
+                                {
+                                    "lines": [
+                                        {
+                                            "content": "<span class=\"n n-ExecutingNode\">f</span><span class=\"p p-ExecutingNode\">()</span>",
+                                            "is_current": true,
+                                            "lineno": 3,
+                                            "type": "line"
+                                        }
+                                    ],
+                                    "name": "<module>",
+                                    "type": "frame",
+                                    "variables": [
+                                        {
+                                            "name": "<span class=\"n\">f</span>\n",
+                                            "value": "<span class=\"s1\">&#39;a string&#39;</span>\n"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "friendly": "<p>A <code>TypeError</code> is usually caused by trying\nto combine two incompatible types of objects,\nby calling a function with the wrong type of object,\nor by tring to do an operation not allowed on a given type of object.</p>\n<p>I suspect that you had an object of this type, a string (<code>str</code>),\nfollowed by what looked like a tuple, '(...)',\nwhich Python took as an indication of a function call.\nPerhaps you had a missing comma before the tuple.</p>",
+                            "tail": ""
+                        }
+                    ]
                 },
                 {
                     "color": "white",
@@ -4171,20 +4218,43 @@
                     "text": "\n"
                 },
                 {
+                    "codeSource": "editor",
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": " File \"my_program.py\", line 2, in <module>\n"
-                },
-                {
-                    "color": "red",
-                    "text": "-->    2 | \u001b[38;5;15mlength\u001b[39m\u001b[38;5;15m \u001b[39m\u001b[38;5;197m=\u001b[39m\u001b[38;5;15m \u001b[39m\u001b[38;5;15;48;5;24mlen\u001b[39;49m\u001b[38;5;15;48;5;24m(\u001b[39;49m\u001b[38;5;15;48;5;24mthings\u001b[39;49m\u001b[38;5;15;48;5;24m)\u001b[39;49m\n"
-                },
-                {
-                    "color": "red",
-                    "text": "TypeError: object of type 'NoneType' has no len()\n"
+                    "isTraceback": true,
+                    "text": "TypeError: object of type 'NoneType' has no len()",
+                    "tracebacks": [
+                        {
+                            "didyoumean": [
+                                "implement \"__len__\" on NoneType"
+                            ],
+                            "exception": {
+                                "message": "object of type 'NoneType' has no len()",
+                                "type": "TypeError"
+                            },
+                            "frames": [
+                                {
+                                    "lines": [
+                                        {
+                                            "content": "<span class=\"n\">length</span> <span class=\"o\">=</span> <span class=\"nb nb-ExecutingNode\">len</span><span class=\"p p-ExecutingNode\">(</span><span class=\"n n-ExecutingNode\">things</span><span class=\"p p-ExecutingNode\">)</span>",
+                                            "is_current": true,
+                                            "lineno": 2,
+                                            "type": "line"
+                                        }
+                                    ],
+                                    "name": "<module>",
+                                    "type": "frame",
+                                    "variables": [
+                                        {
+                                            "name": "<span class=\"n\">things</span>\n",
+                                            "value": "<span class=\"kc\">None</span>\n"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "friendly": "<p>A <code>TypeError</code> is usually caused by trying\nto combine two incompatible types of objects,\nby calling a function with the wrong type of object,\nor by tring to do an operation not allowed on a given type of object.</p>\n<p>I do not recognize this case. Please report it to\nhttps://github.com/aroberge/friendly-traceback/issues</p>",
+                            "tail": ""
+                        }
+                    ]
                 },
                 {
                     "color": "white",
@@ -4240,20 +4310,41 @@
             "passed": true,
             "result": [
                 {
+                    "codeSource": "editor",
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": " File \"my_program.py\", line 2, in <module>\n"
-                },
-                {
-                    "color": "red",
-                    "text": "-->    2 | \u001b[38;5;15;48;5;24mword\u001b[39;49m\u001b[38;5;197;48;5;24m.\u001b[39;49m\u001b[38;5;15;48;5;24mappend\u001b[39;49m\u001b[38;5;15m(\u001b[39m\u001b[38;5;186m'\u001b[39m\u001b[38;5;186m!\u001b[39m\u001b[38;5;186m'\u001b[39m\u001b[38;5;15m)\u001b[39m\n"
-                },
-                {
-                    "color": "red",
-                    "text": "AttributeError: 'str' object has no attribute 'append'\n"
+                    "isTraceback": true,
+                    "text": "AttributeError: 'str' object has no attribute 'append'",
+                    "tracebacks": [
+                        {
+                            "didyoumean": [],
+                            "exception": {
+                                "message": "'str' object has no attribute 'append'",
+                                "type": "AttributeError"
+                            },
+                            "frames": [
+                                {
+                                    "lines": [
+                                        {
+                                            "content": "<span class=\"n n-ExecutingNode\">word</span><span class=\"o o-ExecutingNode\">.</span><span class=\"n n-ExecutingNode\">append</span><span class=\"p\">(</span><span class=\"s1\">&#39;!&#39;</span><span class=\"p\">)</span>",
+                                            "is_current": true,
+                                            "lineno": 2,
+                                            "type": "line"
+                                        }
+                                    ],
+                                    "name": "<module>",
+                                    "type": "frame",
+                                    "variables": [
+                                        {
+                                            "name": "<span class=\"n\">word</span>\n",
+                                            "value": "<span class=\"s1\">&#39;Hello&#39;</span>\n"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "friendly": "<p>An <code>AttributeError</code> occurs when the code contains something like\n    <code>object.x</code>\nand <code>x</code> is not a method or attribute (variable) belonging to <code>object</code>.</p>\n<p>In your program, the object is <code>str</code> and the attribute is <code>append</code>.</p>",
+                            "tail": ""
+                        }
+                    ]
                 },
                 {
                     "color": "white",
@@ -4635,20 +4726,36 @@
             "passed": true,
             "result": [
                 {
+                    "codeSource": "shell",
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": " File \"my_program.py\", line 1, in <module>\n"
-                },
-                {
-                    "color": "red",
-                    "text": "-->    1 | \u001b[38;5;186m'\u001b[39m\u001b[38;5;186mPython\u001b[39m\u001b[38;5;186m'\u001b[39m\u001b[38;5;197m.\u001b[39m\u001b[38;5;15mappend\u001b[39m\u001b[38;5;15m(\u001b[39m\u001b[38;5;186m'\u001b[39m\u001b[38;5;186m is cool!\u001b[39m\u001b[38;5;186m'\u001b[39m\u001b[38;5;15m)\u001b[39m\n"
-                },
-                {
-                    "color": "red",
-                    "text": "AttributeError: 'str' object has no attribute 'append'\n"
+                    "isTraceback": true,
+                    "text": "AttributeError: 'str' object has no attribute 'append'",
+                    "tracebacks": [
+                        {
+                            "didyoumean": [],
+                            "exception": {
+                                "message": "'str' object has no attribute 'append'",
+                                "type": "AttributeError"
+                            },
+                            "frames": [
+                                {
+                                    "lines": [
+                                        {
+                                            "content": "<span class=\"s1\">&#39;Python&#39;</span><span class=\"o\">.</span><span class=\"n\">append</span><span class=\"p\">(</span><span class=\"s1\">&#39; is cool!&#39;</span><span class=\"p\">)</span>",
+                                            "is_current": true,
+                                            "lineno": 1,
+                                            "type": "line"
+                                        }
+                                    ],
+                                    "name": "<module>",
+                                    "type": "frame",
+                                    "variables": []
+                                }
+                            ],
+                            "friendly": "<p>An <code>AttributeError</code> occurs when the code contains something like\n    <code>object.x</code>\nand <code>x</code> is not a method or attribute (variable) belonging to <code>object</code>.</p>\n<p>In your program, the object is <code>str</code> and the attribute is <code>append</code>.</p>",
+                            "tail": ""
+                        }
+                    ]
                 },
                 {
                     "color": "white",
@@ -4993,20 +5100,49 @@
             "passed": true,
             "result": [
                 {
+                    "codeSource": "pythontutor",
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": " File \"my_program.py\", line 3, in <module>\n"
-                },
-                {
-                    "color": "red",
-                    "text": "-->    3 | \u001b[38;5;15m\u001b[39m\u001b[38;5;15mnumber\u001b[39m\u001b[38;5;15m \u001b[39m\u001b[38;5;197m=\u001b[39m\u001b[38;5;15m \u001b[39m\u001b[38;5;15;48;5;24mnumbers\u001b[39;49m\u001b[38;5;15;48;5;24m[\u001b[39;49m\u001b[38;5;15;48;5;24mi\u001b[39;49m\u001b[38;5;15;48;5;24m]\u001b[39;49m\n"
-                },
-                {
-                    "color": "red",
-                    "text": "IndexError: list index out of range\n"
+                    "isTraceback": true,
+                    "text": "IndexError: list index out of range",
+                    "tracebacks": [
+                        {
+                            "didyoumean": [],
+                            "exception": {
+                                "message": "list index out of range",
+                                "type": "IndexError"
+                            },
+                            "frames": [
+                                {
+                                    "lines": [
+                                        {
+                                            "content": "<span class=\"n\">number</span> <span class=\"o\">=</span> <span class=\"n n-ExecutingNode\">numbers</span><span class=\"p p-ExecutingNode\">[</span><span class=\"n n-ExecutingNode\">i</span><span class=\"p p-ExecutingNode\">]</span>",
+                                            "is_current": true,
+                                            "lineno": 3,
+                                            "type": "line"
+                                        }
+                                    ],
+                                    "name": "<module>",
+                                    "type": "frame",
+                                    "variables": [
+                                        {
+                                            "name": "<span class=\"n\">i</span>\n",
+                                            "value": "<span class=\"mi\">4</span>\n"
+                                        },
+                                        {
+                                            "name": "<span class=\"n\">number</span>\n",
+                                            "value": "<span class=\"mi\">15</span>\n"
+                                        },
+                                        {
+                                            "name": "<span class=\"n\">numbers</span>\n",
+                                            "value": "<span class=\"p\">[</span><span class=\"mi\">7</span><span class=\"p\">,</span> <span class=\"mi\">3</span><span class=\"p\">,</span> <span class=\"mi\">12</span><span class=\"p\">,</span> <span class=\"mi\">15</span><span class=\"p\">]</span>\n"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "friendly": "<p>An <code>IndexError</code> occurs when you are try to get an item from a list,\na tuple, or a similar object (sequence), by using an index which\ndoes not exists; typically, this is because the index you give\nis greater than the length of the sequence.\nReminder: the first item of a sequence is at index 0.</p>",
+                            "tail": ""
+                        }
+                    ]
                 },
                 {
                     "color": "white",
@@ -5712,20 +5848,36 @@
             "passed": false,
             "result": [
                 {
+                    "codeSource": "shell",
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": " File \"my_program.py\", line 1, in <module>\n"
-                },
-                {
-                    "color": "red",
-                    "text": "-->    1 | \u001b[38;5;15mprint\u001b[39m\u001b[38;5;15m(\u001b[39m\u001b[38;5;141m1\u001b[39m\u001b[38;5;15m \u001b[39m\u001b[38;5;197m+\u001b[39m\u001b[38;5;15m \u001b[39m\u001b[38;5;186m\"\u001b[39m\u001b[38;5;186mx\u001b[39m\u001b[38;5;186m\"\u001b[39m\u001b[38;5;15m)\u001b[39m\n"
-                },
-                {
-                    "color": "red",
-                    "text": "TypeError: unsupported operand type(s) for +: 'int' and 'str'\n"
+                    "isTraceback": true,
+                    "text": "TypeError: unsupported operand type(s) for +: 'int' and 'str'",
+                    "tracebacks": [
+                        {
+                            "didyoumean": [],
+                            "exception": {
+                                "message": "unsupported operand type(s) for +: 'int' and 'str'",
+                                "type": "TypeError"
+                            },
+                            "frames": [
+                                {
+                                    "lines": [
+                                        {
+                                            "content": "<span class=\"nb\">print</span><span class=\"p\">(</span><span class=\"mi\">1</span> <span class=\"o\">+</span> <span class=\"s2\">&quot;x&quot;</span><span class=\"p\">)</span>",
+                                            "is_current": true,
+                                            "lineno": 1,
+                                            "type": "line"
+                                        }
+                                    ],
+                                    "name": "<module>",
+                                    "type": "frame",
+                                    "variables": []
+                                }
+                            ],
+                            "friendly": "<p>A <code>TypeError</code> is usually caused by trying\nto combine two incompatible types of objects,\nby calling a function with the wrong type of object,\nor by tring to do an operation not allowed on a given type of object.</p>\n<p>You tried to add two incompatible types of objects:\nan integer (<code>int</code>) and a string (<code>str</code>)</p>",
+                            "tail": ""
+                        }
+                    ]
                 },
                 {
                     "color": "white",
@@ -9309,43 +9461,6 @@
                 {
                     "color": "white",
                     "text": "\n"
-                },
-                {
-                    "color": "white",
-                    "text": ">>> "
-                }
-            ]
-        },
-        "step": "times_table_exercise"
-    },
-    {
-        "page": "Introducing Nested Loops",
-        "program": [
-            "2 x 3"
-        ],
-        "response": {
-            "message": "<p>To multiply numbers, use <code>*</code></p>",
-            "passed": false,
-            "result": [
-                {
-                    "color": "red",
-                    "text": "Traceback (most recent call last):\n"
-                },
-                {
-                    "color": "red",
-                    "text": "  File \"my_program.py\", line 1\n"
-                },
-                {
-                    "color": "red",
-                    "text": "    2 x 3\n"
-                },
-                {
-                    "color": "red",
-                    "text": "      ^\n"
-                },
-                {
-                    "color": "red",
-                    "text": "SyntaxError: invalid syntax\n"
                 },
                 {
                     "color": "white",
@@ -17376,23 +17491,11 @@
             "result": [
                 {
                     "color": "red",
-                    "text": "Traceback (most recent call last):\n"
+                    "text": "    is_friend = name == \"Alice\" or\n                                 ^\nSyntaxError: invalid syntax\nat line 1\n\nA `SyntaxError` occurs when Python cannot understand your code.\n\nI make an effort below to guess what caused the problem\nbut I might guess incorrectly.\n\nThere appears to be a Python identifier (variable name)\nimmediately following a string.\nI suspect that you were trying to use a quote inside a string\nthat was enclosed in quotes of the same kind.\n"
                 },
                 {
                     "color": "red",
-                    "text": "  File \"my_program.py\", line 1\n"
-                },
-                {
-                    "color": "red",
-                    "text": "    is_friend = name == \"Alice\" or\n"
-                },
-                {
-                    "color": "red",
-                    "text": "                                 ^\n"
-                },
-                {
-                    "color": "red",
-                    "text": "SyntaxError: invalid syntax\n"
+                    "text": "\n"
                 },
                 {
                     "color": "white",

--- a/backend/main/test_transcript.json
+++ b/backend/main/test_transcript.json
@@ -325,7 +325,7 @@
                                     "variables": []
                                 }
                             ],
-                            "friendly": "<p>A <code>NameError</code> exception indicates that a variable or\nfunction name is not known to Python.\nMost often, this is because there is a spelling mistake.\nHowever, sometimes it is because the name is used\nbefore being defined or given a value.</p>",
+                            "friendly": "<p>A <code>NameError</code> exception indicates that a variable or\nfunction name is not known to Python.\nMost often, this is because there is a spelling mistake.\nHowever, sometimes it is because the name is used\nbefore being defined or given a value.</p>\n<p>In your program, the unknown name is <code>sunshine</code>.</p>",
                             "tail": ""
                         }
                     ]
@@ -2510,7 +2510,7 @@
                                     ]
                                 }
                             ],
-                            "friendly": "<p>A <code>NameError</code> exception indicates that a variable or\nfunction name is not known to Python.\nMost often, this is because there is a spelling mistake.\nHowever, sometimes it is because the name is used\nbefore being defined or given a value.</p>",
+                            "friendly": "<p>A <code>NameError</code> exception indicates that a variable or\nfunction name is not known to Python.\nMost often, this is because there is a spelling mistake.\nHowever, sometimes it is because the name is used\nbefore being defined or given a value.</p>\n<p>In your program, the unknown name is <code>char</code>.\nThe Python builtin <code>'chr'</code> has a similar name. </p>",
                             "tail": ""
                         }
                     ]

--- a/backend/main/test_transcript.json
+++ b/backend/main/test_transcript.json
@@ -52,31 +52,6 @@
     {
         "page": "Introducing The Shell",
         "program": [
-            "3 x 4"
-        ],
-        "response": {
-            "message": "<p>I see an 'x'. If you're trying to multiply, use an asterisk, e.g:</p>\n\n<pre><code class=\"codehilite\"><span><span class=\"mi\">3</span> <span class=\"o\">*</span> <span class=\"mi\">4</span>\n</span></code></pre>",
-            "passed": false,
-            "result": [
-                {
-                    "color": "red",
-                    "text": "    3 x 4\n      ^\nSyntaxError: invalid syntax\nat line 1\n\nA `SyntaxError` occurs when Python cannot understand your code.\n\nCurrently, I cannot guess the likely cause of this error.\nTry to examine closely the line indicated as well as the line\nimmediately above to see if you can identify some misspelled\nword, or missing symbols, like (, ), [, ], :, etc.\n\nYou might want to report this case to\nhttps://github.com/aroberge/friendly-traceback/issues\n\n"
-                },
-                {
-                    "color": "red",
-                    "text": "\n"
-                },
-                {
-                    "color": "white",
-                    "text": ">>> "
-                }
-            ]
-        },
-        "step": "more_calculation"
-    },
-    {
-        "page": "Introducing The Shell",
-        "program": [
             "5 - 6"
         ],
         "response": {

--- a/backend/main/utils/__init__.py
+++ b/backend/main/utils/__init__.py
@@ -109,24 +109,6 @@ def format_exception_string():
     return ''.join(traceback.format_exception_only(*sys.exc_info()[:2]))
 
 
-class Formatter(stack_data.Formatter):
-    def format_frame(self, frame):
-        if frame.filename.startswith(internal_dir):
-            return
-        yield from super().format_frame(frame)
-
-
-formatter = Formatter(
-    options=stack_data.Options(before=0, after=0),
-    pygmented=True,
-    show_executing_node=True,
-)
-
-
-def print_exception():
-    formatter.print_exception()
-
-
 def row_to_dict(row):
     d = row.__dict__.copy()
     del d["_sa_instance_state"]

--- a/backend/main/utils/__init__.py
+++ b/backend/main/utils/__init__.py
@@ -23,6 +23,12 @@ from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_lexer_by_name
 from pygments.styles import get_style_by_name
 
+site_packages = strip_required_suffix(pygments.__file__, "pygments/__init__.py")
+sys.path.append(site_packages + "didyoumean/")
+
+from didyoumean.didyoumean_internal import get_suggestions_for_exception  # noqa
+
+
 lexer = get_lexer_by_name("python3")
 monokai = get_style_by_name("monokai")
 html_formatter = HtmlFormatter(nowrap=True)

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -95,10 +95,17 @@ class API:
 
         output_parts = result["output_parts"]
         if not result["awaiting_input"]:
-            if result["traceback_info"]:
-                output_parts.append(
-                    dict(isTraceback=True, data=result["traceback_info"])
-                )
+            traceback_info = result["traceback_info"]
+            if traceback_info:
+                if source == "shell" and len(traceback_info) == 1 and len(traceback_info[0]["frames"]) == 1:
+                    exception = traceback_info[0]["exception"]
+                    output_parts.append(
+                        dict(text=f"{exception['type']}: {exception['message']}\n", color="red")
+                    )
+                else:
+                    output_parts.append(
+                        dict(isTraceback=True, data=traceback_info)
+                    )
             output_parts.append(dict(text=">>> ", color="white"))
 
         birdseye_url = None

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -97,7 +97,12 @@ class API:
         if not result["awaiting_input"]:
             traceback_info = result["traceback_info"]
             if traceback_info:
-                if source == "shell" and len(traceback_info) == 1 and len(traceback_info[0]["frames"]) == 1:
+                if (
+                    source == "shell"
+                    and len(traceback_info) == 1
+                    and len(traceback_info[0]["frames"]) == 1
+                    and not traceback_info[0]["didyoumean"]
+                ):
                     exception = traceback_info[0]["exception"]
                     output_parts.append(
                         dict(text=f"{exception['type']}: {exception['message']}\n", color="red")

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -95,6 +95,10 @@ class API:
 
         output_parts = result["output_parts"]
         if not result["awaiting_input"]:
+            if result["traceback_info"]:
+                output_parts.append(
+                    dict(isTraceback=True, data=result["traceback_info"])
+                )
             output_parts.append(dict(text=">>> ", color="white"))
 
         birdseye_url = None

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -95,22 +95,6 @@ class API:
 
         output_parts = result["output_parts"]
         if not result["awaiting_input"]:
-            traceback_info = result["traceback_info"]
-            if traceback_info:
-                if (
-                    source == "shell"
-                    and len(traceback_info) == 1
-                    and len(traceback_info[0]["frames"]) == 1
-                    and not traceback_info[0]["didyoumean"]
-                ):
-                    exception = traceback_info[0]["exception"]
-                    output_parts.append(
-                        dict(text=f"{exception['type']}: {exception['message']}\n", color="red")
-                    )
-                else:
-                    output_parts.append(
-                        dict(isTraceback=True, data=traceback_info)
-                    )
             output_parts.append(dict(text=">>> ", color="white"))
 
         birdseye_url = None

--- a/backend/main/workers/birdseye.py
+++ b/backend/main/workers/birdseye.py
@@ -53,8 +53,8 @@ def exec_birdseye(filename, code):
 
     find_code(traced_file.code)
 
-    execute(traced_file.code)
+    traceback_info = execute(traced_file.code)
     with eye.db.session_scope() as session:
         objects = session.query(eye.db.Call, eye.db.Function).all()
         calls, functions = [rows_to_dicts(set(column)) for column in zip(*objects)]
-    return dict(calls=calls, functions=functions)
+    return traceback_info, dict(calls=calls, functions=functions)

--- a/backend/main/workers/limits.py
+++ b/backend/main/workers/limits.py
@@ -4,6 +4,8 @@ import resource
 from functools import lru_cache
 from importlib import import_module
 
+from main.utils import get_suggestions_for_exception
+
 
 def patch_cwd():
     """
@@ -36,10 +38,15 @@ def set_limits():
     except ValueError:
         pass
 
-    from main.workers import birdseye, snoop
-    str([snoop, birdseye])
-
     patch_cwd()
+
+    # Trigger imports before limiting access to files
+    from main.workers import birdseye, snoop  # noqa
+
+    try:
+        sdfsdfsdfsd  # noqa
+    except NameError as e:
+        list(get_suggestions_for_exception(e, e.__traceback__))
 
     resource.setrlimit(resource.RLIMIT_NOFILE, (0, 0))
 

--- a/backend/main/workers/limits.py
+++ b/backend/main/workers/limits.py
@@ -42,6 +42,7 @@ def set_limits():
 
     # Trigger imports before limiting access to files
     from main.workers import birdseye, snoop  # noqa
+    from friendly_traceback.runtime_errors import type_error, attribute_error  # noqa
 
     try:
         sdfsdfsdfsd  # noqa

--- a/backend/main/workers/limits.py
+++ b/backend/main/workers/limits.py
@@ -42,7 +42,17 @@ def set_limits():
 
     # Trigger imports before limiting access to files
     from main.workers import birdseye, snoop  # noqa
-    from friendly_traceback.runtime_errors import type_error, attribute_error  # noqa
+    from friendly_traceback.runtime_errors import (  # noqa
+        type_error,
+        attribute_error,
+        stdlib,
+    )
+    from friendly_traceback.syntax_errors import (  # noqa
+        analyze_syntax,
+        line_analyzer,
+        message_analyzer,
+        source_analyzer,
+    )
 
     try:
         sdfsdfsdfsd  # noqa

--- a/backend/main/workers/snoop.py
+++ b/backend/main/workers/snoop.py
@@ -55,4 +55,4 @@ def exec_snoop(filename, code, code_obj):
     find_code(code_obj)
 
     with tracer:
-        execute(code_obj)
+        return execute(code_obj)

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -5,6 +5,8 @@ from typing import Union, Iterable, List
 
 import pygments
 from cheap_repr import cheap_repr
+from friendly_traceback.core import get_traceback_info
+from markdown import markdown
 from pygments.formatters.html import HtmlFormatter
 from stack_data import (
     style_with_executing_node,
@@ -34,6 +36,13 @@ def didyoumean_suggestions(e) -> List[str]:
     ]
 
 
+def friendly_traceback_info(e):
+    info = get_traceback_info(type(e), e, e.__traceback__)
+    generic = info["generic"]
+    case = info.get("cause", "").replace("\n", "\n\n")
+    return markdown(generic + "\n\n" + case)
+
+
 class TracebackSerializer:
     def format_exception(self, e) -> List[dict]:
         if e.__cause__ is not None:
@@ -54,6 +63,7 @@ class TracebackSerializer:
                 ),
                 tail="",
                 didyoumean=didyoumean_suggestions(e),
+                friendly=friendly_traceback_info(e),
             )
         )
         return result

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -33,11 +33,11 @@ log = logging.getLogger(__name__)
 def didyoumean_suggestions(e) -> List[str]:
     if "maximum recursion depth exceeded" in str(e):
         return []
-    return [
-        suggestion
-        for suggestion in get_suggestions_for_exception(e, e.__traceback__)
-        if 1
-    ]
+    try:
+        return list(get_suggestions_for_exception(e, e.__traceback__))
+    except Exception:
+        log.exception("Failed to get didyoumean suggestions")
+        return []
 
 
 def friendly_traceback_info(e):

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -152,8 +152,12 @@ class TracebackSerializer:
         )
 
     def format_variables(self, frame_info: FrameInfo) -> Iterable[str]:
-        for var in sorted(frame_info.variables, key=lambda v: v.name):
-            yield self.format_variable(var)
+        try:
+            for var in sorted(frame_info.variables, key=lambda v: v.name):
+                yield self.format_variable(var)
+        except Exception:
+            log.exception("Error in getting frame variables")
+            return []
 
     def format_variable(self, var: Variable) -> dict:
         return dict(

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -39,7 +39,7 @@ def didyoumean_suggestions(e) -> List[str]:
 def friendly_traceback_info(e):
     info = get_traceback_info(type(e), e, e.__traceback__)
     generic = info["generic"]
-    case = info.get("cause", "").replace("\n", "\n\n")
+    case = info.get("cause", "")
     return markdown(generic + "\n\n" + case)
 
 

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -1,0 +1,135 @@
+import json
+import traceback
+from collections import Counter
+from typing import Union, Iterable, List
+
+from cheap_repr import cheap_repr
+from executing import Source
+from pygments.formatters.html import HtmlFormatter
+from stack_data import (
+    style_with_executing_node,
+    Options,
+    Line,
+    FrameInfo,
+    Variable,
+    RepeatedFrames,
+)
+
+from main.utils import internal_dir
+
+pygments_style = style_with_executing_node("monokai", "bg:#005080")
+pygments_formatter = HtmlFormatter(
+    style=pygments_style,
+    nowrap=True,
+)
+
+
+class TracebackSerializer:
+    def format_exception(self, e) -> List[dict]:
+        if e.__cause__ is not None:
+            result = self.format_exception(e.__cause__)
+            result[-1]["tail"] = traceback._cause_message
+        elif e.__context__ is not None and not e.__suppress_context__:
+            result = self.format_exception(e.__context__)
+            result[-1]["tail"] = traceback._context_message
+        else:
+            result = []
+
+        result.append(
+            dict(
+                frames=self.format_stack(e.__traceback__),
+                exception=dict(
+                    type=type(e).__name__,
+                    message=traceback._some_str(e),
+                ),
+                tail="",
+            )
+        )
+        return result
+
+    def format_stack(self, frame_or_tb) -> List[dict]:
+        return list(
+            self.format_stack_data(
+                FrameInfo.stack_data(
+                    frame_or_tb,
+                    Options(before=0, after=0, pygments_formatter=pygments_formatter),
+                    collapse_repeated_frames=True,
+                )
+            )
+        )
+
+    def format_stack_data(
+        self, stack: Iterable[Union[FrameInfo, RepeatedFrames]]
+    ) -> Iterable[dict]:
+        for item in stack:
+            if isinstance(item, FrameInfo):
+                if item.filename != "my_program.py":
+                    continue
+                yield self.format_frame(item)
+            else:
+                yield self.format_repeated_frames(item)
+
+    def format_repeated_frames(self, repeated_frames: RepeatedFrames) -> List[dict]:
+        counts = sorted(
+            Counter(repeated_frames.frame_keys).items(),
+            key=lambda item: (-item[1], item[0][0].co_name),
+        )
+        return [
+            dict(
+                name=code.co_name,
+                lineno=lineno,
+                count=count,
+            )
+            for (code, lineno), count in counts
+        ]
+
+    def format_frame(self, frame: FrameInfo) -> dict:
+        return dict(
+            type="frame",
+            name=frame.executing.code_qualname(),
+            variables=list(self.format_variables(frame)),
+            lines=list(self.format_lines(frame.lines)),
+        )
+
+    def format_lines(self, lines):
+        for line in lines:
+            if isinstance(line, Line):
+                yield self.format_line(line)
+            else:
+                yield dict(type="line_gap")
+
+    def format_line(self, line: Line) -> dict:
+        return dict(
+            type="line",
+            is_current=line.is_current,
+            lineno=line.lineno,
+            content=line.render(
+                pygmented=True,
+                escape_html=True,
+                strip_leading_indent=True,
+            ),
+        )
+
+    def format_variables(self, frame_info: FrameInfo) -> Iterable[str]:
+        for var in sorted(frame_info.variables, key=lambda v: v.name):
+            yield self.format_variable(var)
+
+    def format_variable(self, var: Variable) -> dict:
+        return dict(
+            name=var.name,
+            value=cheap_repr(var.value),
+        )
+
+
+def test():
+    def foo():
+        print(1 / 0)
+
+    try:
+        foo()
+    except Exception as e:
+        print(json.dumps(TracebackSerializer().format_exception(e), indent=4))
+
+
+if __name__ == "__main__":
+    test()

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -5,7 +5,6 @@ from typing import Union, Iterable, List
 
 import pygments
 from cheap_repr import cheap_repr
-from executing import Source
 from pygments.formatters.html import HtmlFormatter
 from stack_data import (
     style_with_executing_node,
@@ -16,13 +15,23 @@ from stack_data import (
     RepeatedFrames,
 )
 
-from main.utils import internal_dir, is_valid_syntax, lexer
+from main.utils import is_valid_syntax, lexer, get_suggestions_for_exception
 
 pygments_style = style_with_executing_node("monokai", "bg:#005080")
 pygments_formatter = HtmlFormatter(
     style=pygments_style,
     nowrap=True,
 )
+
+
+def didyoumean_suggestions(e) -> List[str]:
+    if "maximum recursion depth exceeded" in str(e):
+        return []
+    return [
+        suggestion
+        for suggestion in get_suggestions_for_exception(e, e.__traceback__)
+        if 1
+    ]
 
 
 class TracebackSerializer:
@@ -44,6 +53,7 @@ class TracebackSerializer:
                     message=traceback._some_str(e),
                 ),
                 tail="",
+                didyoumean=didyoumean_suggestions(e),
             )
         )
         return result

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -68,7 +68,9 @@ class TracebackSerializer:
                     continue
                 yield self.format_frame(item)
             else:
-                yield self.format_repeated_frames(item)
+                yield dict(
+                    type="repeated_frames", data=self.format_repeated_frames(item)
+                )
 
     def format_repeated_frames(self, repeated_frames: RepeatedFrames) -> List[dict]:
         counts = sorted(

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -1,3 +1,4 @@
+import html
 import json
 import logging
 import sys
@@ -197,7 +198,7 @@ def maybe_highlight(text):
     if is_valid_syntax(text):
         return pygments.highlight(text, lexer, pygments_formatter)
     else:
-        return text
+        return html.escape(text)
 
 
 def test():

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -50,27 +50,24 @@ def friendly_generic(e):
         return ""
 
 
-def friendly_runtime_cause(e):
-    info = {}
-    frame = e.__traceback__.tb_frame
+def _friendly_cause(e, setter):
+    info = {"message": get_message(type(e).__name__, e)}
     try:
-        get_likely_cause(type(e), e, info, frame)
+        setter(info)
     except Exception:
         log.exception("Failed to get likely cause of exception")
         return ""
     else:
         return info.get("cause", "")
+
+
+def friendly_runtime_cause(e):
+    frame = e.__traceback__.tb_frame
+    return _friendly_cause(e, lambda info: get_likely_cause(type(e), e, info, frame))
 
 
 def friendly_syntax_cause(e):
-    info = {"message": get_message(type(e).__name__, e)}
-    try:
-        analyze_syntax.set_cause_syntax(type(e), e, info)
-    except Exception:
-        log.exception("Failed to get likely cause of exception")
-        return ""
-    else:
-        return info.get("cause", "")
+    return _friendly_cause(e, lambda info: analyze_syntax.set_cause_syntax(type(e), e, info))
 
 
 def print_friendly_syntax_error(e):

--- a/backend/main/workers/tracebacks.py
+++ b/backend/main/workers/tracebacks.py
@@ -3,6 +3,7 @@ import traceback
 from collections import Counter
 from typing import Union, Iterable, List
 
+import pygments
 from cheap_repr import cheap_repr
 from executing import Source
 from pygments.formatters.html import HtmlFormatter
@@ -15,7 +16,7 @@ from stack_data import (
     RepeatedFrames,
 )
 
-from main.utils import internal_dir
+from main.utils import internal_dir, is_valid_syntax, lexer
 
 pygments_style = style_with_executing_node("monokai", "bg:#005080")
 pygments_formatter = HtmlFormatter(
@@ -116,9 +117,16 @@ class TracebackSerializer:
 
     def format_variable(self, var: Variable) -> dict:
         return dict(
-            name=var.name,
-            value=cheap_repr(var.value),
+            name=maybe_highlight(var.name),
+            value=maybe_highlight(cheap_repr(var.value)),
         )
+
+
+def maybe_highlight(text):
+    if is_valid_syntax(text):
+        return pygments.highlight(text, lexer, pygments_formatter)
+    else:
+        return text
 
 
 def test():

--- a/backend/main/workers/utils.py
+++ b/backend/main/workers/utils.py
@@ -52,6 +52,7 @@ def make_result(
         output_parts=None,
         birdseye_objects=None,
         error=None,
+        traceback_info=None,
 ):
     if output is None:
         output = output_buffer.string()
@@ -67,6 +68,7 @@ def make_result(
         output_parts=output_parts,
         birdseye_objects=birdseye_objects,
         error=error,
+        traceback_info=traceback_info,
     )
     # Check that JSON encoding works here
     # because failures in the queue pickling are silent

--- a/backend/main/workers/utils.py
+++ b/backend/main/workers/utils.py
@@ -52,7 +52,6 @@ def make_result(
         output_parts=None,
         birdseye_objects=None,
         error=None,
-        traceback_info=None,
 ):
     if output is None:
         output = output_buffer.string()
@@ -68,7 +67,6 @@ def make_result(
         output_parts=output_parts,
         birdseye_objects=birdseye_objects,
         error=error,
-        traceback_info=traceback_info,
     )
     # Check that JSON encoding works here
     # because failures in the queue pickling are silent

--- a/backend/main/workers/worker.py
+++ b/backend/main/workers/worker.py
@@ -68,7 +68,18 @@ def runner(code_source, code):
     else:
         traceback_info = execute(code_obj)
 
-    return traceback_info, birdseye_objects
+    if traceback_info:
+        exception = traceback_info[-1]["exception"]
+        traceback_info = dict(
+            isTraceback=True,
+            codeSource=code_source,
+            tracebacks=traceback_info,
+            text=f"{exception['type']}: {exception['message']}",
+            color="red",
+        )
+        output_buffer.parts.append(traceback_info)
+
+    return birdseye_objects
 
 
 def worker_loop_in_thread(*args):
@@ -110,7 +121,7 @@ def run_code(entry, input_queue, result_queue):
     try:
         sys.stdout = output_buffer.stdout
         sys.stderr = output_buffer.stderr
-        traceback_info, birdseye_objects = runner(entry['source'], entry['input'])
+        birdseye_objects = runner(entry['source'], entry['input'])
     finally:
         sys.stdout = orig_stdout
         sys.stderr = orig_stderr
@@ -133,5 +144,4 @@ def run_code(entry, input_queue, result_queue):
         message=message,
         output=output,
         birdseye_objects=birdseye_objects,
-        traceback_info=traceback_info,
     ))

--- a/backend/main/workers/worker.py
+++ b/backend/main/workers/worker.py
@@ -51,7 +51,7 @@ def runner(code_source, code):
         code_obj = compile(code, filename, mode)
     except SyntaxError:
         print_exception()
-        return {}
+        return None, {}
 
     birdseye_objects = None
 

--- a/backend/main/workers/worker.py
+++ b/backend/main/workers/worker.py
@@ -6,13 +6,13 @@ from code import InteractiveConsole
 from threading import Thread
 from time import sleep
 
+import friendly_traceback.source_cache
 import stack_data
 
 from main.exercises import assert_equal
 from main.text import pages
-from main.utils import print_exception
 from main.workers.limits import set_limits
-from main.workers.tracebacks import TracebackSerializer
+from main.workers.tracebacks import TracebackSerializer, print_friendly_syntax_error
 from main.workers.utils import internal_error_result, make_result, output_buffer
 
 log = logging.getLogger(__name__)
@@ -51,10 +51,12 @@ def runner(code_source, code):
 
     stack_data.Source._class_local('__source_cache', {}).pop(filename, None)
 
+    friendly_traceback.source_cache.cache.replace({filename: code})
+
     try:
         code_obj = compile(code, filename, mode)
-    except SyntaxError:
-        print_exception()
+    except SyntaxError as e:
+        print_friendly_syntax_error(e)
         return {}
 
     birdseye_objects = None

--- a/backend/main/workers/worker.py
+++ b/backend/main/workers/worker.py
@@ -55,7 +55,7 @@ def runner(code_source, code):
         code_obj = compile(code, filename, mode)
     except SyntaxError:
         print_exception()
-        return None, {}
+        return {}
 
     birdseye_objects = None
 

--- a/backend/main/workers/worker.py
+++ b/backend/main/workers/worker.py
@@ -22,11 +22,15 @@ console.locals = {"assert_equal": assert_equal}
 
 
 def execute(code_obj):
+    sys.setrecursionlimit(100)
     try:
         # noinspection PyTypeChecker
         exec(code_obj, console.locals)
     except Exception as e:
+        sys.setrecursionlimit(1000)
         return TracebackSerializer().format_exception(e)
+    finally:
+        sys.setrecursionlimit(1000)
 
 
 def runner(code_source, code):

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,7 +36,7 @@ import {animateScroll} from "react-scroll";
 import {HintsPopup} from "./Hints";
 import Toggle from 'react-toggle'
 import "react-toggle/style.css"
-import {ErrorModal, FeedbackModal} from "./Feedback";
+import {ErrorModal, feedbackContentStyle, FeedbackModal} from "./Feedback";
 import birdseyeIcon from "./img/birdseye_icon.png";
 import _ from "lodash";
 
@@ -300,6 +300,7 @@ const MenuPopup = ({user}) =>
             trigger={<a href="#"><FontAwesomeIcon icon={faBug}/> Feedback </a>}
             modal
             closeOnDocumentClick
+            contentStyle={feedbackContentStyle}
           >
             {close => <FeedbackModal close={close}/>}
           </Popup>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -231,7 +231,8 @@ class AppComponent extends React.Component {
               }}
               fontSize="15px"
               setOptions={{
-                fontFamily: "monospace"
+                fontFamily: "monospace",
+                showPrintMargin: false,
               }}
               readOnly={cantUseEditor}
             />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -214,7 +214,7 @@ class AppComponent extends React.Component {
 
         </div>
         <div className="editor-and-terminal">
-          <div className={"editor " + (showEditor ? "" : "invisible")}>
+          {showEditor && <div className="editor">
             <AceEditor
               mode="python"
               theme="monokai"
@@ -236,8 +236,8 @@ class AppComponent extends React.Component {
               }}
               readOnly={cantUseEditor}
             />
-          </div>
-          <div className="terminal">
+          </div>}
+          <div className="terminal" style={{height: showEditor ? "49%" : "100%"}}>
             <Terminal
               onCommand={(cmd) => this.runCode({code: cmd, source: "shell"})}
               ref={terminalRef}

--- a/frontend/src/Feedback.js
+++ b/frontend/src/Feedback.js
@@ -105,8 +105,15 @@ export const ErrorModal = ({error}) => {
       open={true}
       closeOnDocumentClick
       onClose={() => rpcStateSet("error", null)}
+      contentStyle={feedbackContentStyle}
     >
       {close => <FeedbackModal close={close} error={error}/>}
     </Popup>
   )
 };
+
+
+export const feedbackContentStyle = {
+  maxHeight: "90vh",
+  overflow: "auto",
+}

--- a/frontend/src/css/github-markdown.css
+++ b/frontend/src/css/github-markdown.css
@@ -723,7 +723,7 @@
 
 .markdown-body .highlight pre,
 .markdown-body pre {
-  background-color: rgb(46, 46, 46);
+  background-color: rgb(39, 40, 34);
   border-radius: 3px;
   font-size: 15px;
   line-height: 1.45;

--- a/frontend/src/css/main.scss
+++ b/frontend/src/css/main.scss
@@ -190,6 +190,10 @@
       }
 
     }
+
+    .traceback-repeated-frames {
+      margin: 1.5em;
+    }
   }
   .traceback-exception {
     font-size: 120%;

--- a/frontend/src/css/main.scss
+++ b/frontend/src/css/main.scss
@@ -147,6 +147,43 @@
   }
 }
 
+.tracebacks-container {
+  .traceback {
+    .traceback-frame {
+      border: 1px solid grey;
+      border-radius: 8px;
+      padding: 0.5em;
+      margin-top: 3px;
+
+      .traceback-frame-name {
+        font-weight: bold;
+      }
+
+      table {
+        margin-top: 0.25em;
+      }
+
+      .traceback-line-content {
+        padding-left: 8px;
+      }
+
+      .traceback-lineno {
+        background: #2F3129;
+        color: #8F908A;
+        min-width: 32px;
+        padding-right: 11px;
+        text-align: right;
+      }
+
+    }
+    .traceback-exception {
+      font-size: 120%;
+      color: red;
+      padding: 0.5em;
+    }
+  }
+}
+
 // override react-popup
 .custom-popup {
   > .popup-content {

--- a/frontend/src/css/main.scss
+++ b/frontend/src/css/main.scss
@@ -190,11 +190,11 @@
       }
 
     }
-    .traceback-exception {
-      font-size: 120%;
-      color: red;
-      padding: 0.5em;
-    }
+  }
+  .traceback-exception {
+    font-size: 120%;
+    color: red;
+    padding: 0.5em;
   }
 }
 

--- a/frontend/src/css/main.scss
+++ b/frontend/src/css/main.scss
@@ -165,6 +165,7 @@
 
       .traceback-line-content {
         padding-left: 8px;
+        white-space: pre;
       }
 
       .traceback-lineno {

--- a/frontend/src/css/main.scss
+++ b/frontend/src/css/main.scss
@@ -65,10 +65,6 @@
     }
   }
 
-  .terminal p code {
-    color: white;
-  }
-
   .book-text {
     margin-bottom: 3em;
   }

--- a/frontend/src/css/main.scss
+++ b/frontend/src/css/main.scss
@@ -163,6 +163,19 @@
         margin-top: 0.25em;
       }
 
+      .traceback-variables-table {
+        td {
+          border: 1px solid grey;
+          padding: 4px;
+          white-space: pre;
+        }
+
+        td.traceback-variable-name {
+          padding-right: 2em;
+        }
+
+      }
+
       .traceback-line-content {
         padding-left: 8px;
         white-space: pre;

--- a/frontend/src/css/main.scss
+++ b/frontend/src/css/main.scss
@@ -31,8 +31,7 @@
       width: 100%;
       position: absolute;
       bottom: 0;
-      top: 51%;
-      
+
       > div[name=react-console-emulator] {
         height: 100%;
         min-height: unset !important;

--- a/frontend/src/css/main.scss
+++ b/frontend/src/css/main.scss
@@ -220,11 +220,6 @@
   }
 }
 
-.popup-content {
-  max-height: 90vh;
-  overflow: auto;
-}
-
 .my-popup-content {
   background: white;
   z-index: 2;

--- a/frontend/src/css/main.scss
+++ b/frontend/src/css/main.scss
@@ -196,6 +196,10 @@
     color: red;
     padding: 0.5em;
   }
+
+  .traceback-tail {
+    margin: 1em;
+  }
 }
 
 // override react-popup

--- a/frontend/src/css/pygments.css
+++ b/frontend/src/css/pygments.css
@@ -2,19 +2,24 @@
 .codehilite  { background: #272822; color: #f8f8f2 }
 .codehilite .c { color: #75715e } /* Comment */
 .codehilite .err { color: #960050; background-color: #1e0010 } /* Error */
+.codehilite .-ExecutingNode { background-color: #005080 } /* ExecutingNode */
 .codehilite .k { color: #66d9ef } /* Keyword */
 .codehilite .l { color: #ae81ff } /* Literal */
 .codehilite .n { color: #f8f8f2 } /* Name */
 .codehilite .o { color: #f92672 } /* Operator */
 .codehilite .p { color: #f8f8f2 } /* Punctuation */
+.codehilite .c-ExecutingNode { color: #75715e; background-color: #005080 } /* Comment.ExecutingNode */
 .codehilite .ch { color: #75715e } /* Comment.Hashbang */
 .codehilite .cm { color: #75715e } /* Comment.Multiline */
 .codehilite .cp { color: #75715e } /* Comment.Preproc */
 .codehilite .cpf { color: #75715e } /* Comment.PreprocFile */
 .codehilite .c1 { color: #75715e } /* Comment.Single */
 .codehilite .cs { color: #75715e } /* Comment.Special */
+.codehilite .err-ExecutingNode { color: #960050; background-color: #005080 } /* Error.ExecutingNode */
+.codehilite .esc-ExecutingNode { background-color: #005080 } /* Escape.ExecutingNode */
 .codehilite .gd { color: #f92672 } /* Generic.Deleted */
 .codehilite .ge { font-style: italic } /* Generic.Emph */
+.codehilite .g-ExecutingNode { background-color: #005080 } /* Generic.ExecutingNode */
 .codehilite .gi { color: #a6e22e } /* Generic.Inserted */
 .codehilite .go { color: #66d9ef } /* Generic.Output */
 .codehilite .gp { color: #f92672; font-weight: bold } /* Generic.Prompt */
@@ -22,11 +27,13 @@
 .codehilite .gu { color: #75715e } /* Generic.Subheading */
 .codehilite .kc { color: #66d9ef } /* Keyword.Constant */
 .codehilite .kd { color: #66d9ef } /* Keyword.Declaration */
+.codehilite .k-ExecutingNode { color: #66d9ef; background-color: #005080 } /* Keyword.ExecutingNode */
 .codehilite .kn { color: #f92672 } /* Keyword.Namespace */
 .codehilite .kp { color: #66d9ef } /* Keyword.Pseudo */
 .codehilite .kr { color: #66d9ef } /* Keyword.Reserved */
 .codehilite .kt { color: #66d9ef } /* Keyword.Type */
 .codehilite .ld { color: #e6db74 } /* Literal.Date */
+.codehilite .l-ExecutingNode { color: #ae81ff; background-color: #005080 } /* Literal.ExecutingNode */
 .codehilite .m { color: #ae81ff } /* Literal.Number */
 .codehilite .s { color: #e6db74 } /* Literal.String */
 .codehilite .na { color: #a6e22e } /* Name.Attribute */
@@ -36,6 +43,7 @@
 .codehilite .nd { color: #a6e22e } /* Name.Decorator */
 .codehilite .ni { color: #f8f8f2 } /* Name.Entity */
 .codehilite .ne { color: #a6e22e } /* Name.Exception */
+.codehilite .n-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.ExecutingNode */
 .codehilite .nf { color: #a6e22e } /* Name.Function */
 .codehilite .nl { color: #f8f8f2 } /* Name.Label */
 .codehilite .nn { color: #f8f8f2 } /* Name.Namespace */
@@ -43,9 +51,36 @@
 .codehilite .py { color: #f8f8f2 } /* Name.Property */
 .codehilite .nt { color: #f92672 } /* Name.Tag */
 .codehilite .nv { color: #f8f8f2 } /* Name.Variable */
+.codehilite .o-ExecutingNode { color: #f92672; background-color: #005080 } /* Operator.ExecutingNode */
 .codehilite .ow { color: #f92672 } /* Operator.Word */
+.codehilite .x-ExecutingNode { background-color: #005080 } /* Other.ExecutingNode */
+.codehilite .p-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Punctuation.ExecutingNode */
 .codehilite .w { color: #f8f8f2 } /* Text.Whitespace */
+.codehilite .ch-ExecutingNode { color: #75715e; background-color: #005080 } /* Comment.Hashbang.ExecutingNode */
+.codehilite .cm-ExecutingNode { color: #75715e; background-color: #005080 } /* Comment.Multiline.ExecutingNode */
+.codehilite .cp-ExecutingNode { color: #75715e; background-color: #005080 } /* Comment.Preproc.ExecutingNode */
+.codehilite .cpf-ExecutingNode { color: #75715e; background-color: #005080 } /* Comment.PreprocFile.ExecutingNode */
+.codehilite .c1-ExecutingNode { color: #75715e; background-color: #005080 } /* Comment.Single.ExecutingNode */
+.codehilite .cs-ExecutingNode { color: #75715e; background-color: #005080 } /* Comment.Special.ExecutingNode */
+.codehilite .gd-ExecutingNode { color: #f92672; background-color: #005080 } /* Generic.Deleted.ExecutingNode */
+.codehilite .ge-ExecutingNode { font-style: italic; background-color: #005080 } /* Generic.Emph.ExecutingNode */
+.codehilite .gr-ExecutingNode { background-color: #005080 } /* Generic.Error.ExecutingNode */
+.codehilite .gh-ExecutingNode { background-color: #005080 } /* Generic.Heading.ExecutingNode */
+.codehilite .gi-ExecutingNode { color: #a6e22e; background-color: #005080 } /* Generic.Inserted.ExecutingNode */
+.codehilite .go-ExecutingNode { color: #66d9ef; background-color: #005080 } /* Generic.Output.ExecutingNode */
+.codehilite .gp-ExecutingNode { color: #f92672; font-weight: bold; background-color: #005080 } /* Generic.Prompt.ExecutingNode */
+.codehilite .gs-ExecutingNode { font-weight: bold; background-color: #005080 } /* Generic.Strong.ExecutingNode */
+.codehilite .gu-ExecutingNode { color: #75715e; background-color: #005080 } /* Generic.Subheading.ExecutingNode */
+.codehilite .gt-ExecutingNode { background-color: #005080 } /* Generic.Traceback.ExecutingNode */
+.codehilite .kc-ExecutingNode { color: #66d9ef; background-color: #005080 } /* Keyword.Constant.ExecutingNode */
+.codehilite .kd-ExecutingNode { color: #66d9ef; background-color: #005080 } /* Keyword.Declaration.ExecutingNode */
+.codehilite .kn-ExecutingNode { color: #f92672; background-color: #005080 } /* Keyword.Namespace.ExecutingNode */
+.codehilite .kp-ExecutingNode { color: #66d9ef; background-color: #005080 } /* Keyword.Pseudo.ExecutingNode */
+.codehilite .kr-ExecutingNode { color: #66d9ef; background-color: #005080 } /* Keyword.Reserved.ExecutingNode */
+.codehilite .kt-ExecutingNode { color: #66d9ef; background-color: #005080 } /* Keyword.Type.ExecutingNode */
+.codehilite .ld-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.Date.ExecutingNode */
 .codehilite .mb { color: #ae81ff } /* Literal.Number.Bin */
+.codehilite .m-ExecutingNode { color: #ae81ff; background-color: #005080 } /* Literal.Number.ExecutingNode */
 .codehilite .mf { color: #ae81ff } /* Literal.Number.Float */
 .codehilite .mh { color: #ae81ff } /* Literal.Number.Hex */
 .codehilite .mi { color: #ae81ff } /* Literal.Number.Integer */
@@ -57,16 +92,58 @@
 .codehilite .sd { color: #e6db74 } /* Literal.String.Doc */
 .codehilite .s2 { color: #e6db74 } /* Literal.String.Double */
 .codehilite .se { color: #ae81ff } /* Literal.String.Escape */
+.codehilite .s-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.ExecutingNode */
 .codehilite .sh { color: #e6db74 } /* Literal.String.Heredoc */
 .codehilite .si { color: #e6db74 } /* Literal.String.Interpol */
 .codehilite .sx { color: #e6db74 } /* Literal.String.Other */
 .codehilite .sr { color: #e6db74 } /* Literal.String.Regex */
 .codehilite .s1 { color: #e6db74 } /* Literal.String.Single */
 .codehilite .ss { color: #e6db74 } /* Literal.String.Symbol */
+.codehilite .na-ExecutingNode { color: #a6e22e; background-color: #005080 } /* Name.Attribute.ExecutingNode */
+.codehilite .nb-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Builtin.ExecutingNode */
 .codehilite .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
+.codehilite .nc-ExecutingNode { color: #a6e22e; background-color: #005080 } /* Name.Class.ExecutingNode */
+.codehilite .no-ExecutingNode { color: #66d9ef; background-color: #005080 } /* Name.Constant.ExecutingNode */
+.codehilite .nd-ExecutingNode { color: #a6e22e; background-color: #005080 } /* Name.Decorator.ExecutingNode */
+.codehilite .ni-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Entity.ExecutingNode */
+.codehilite .ne-ExecutingNode { color: #a6e22e; background-color: #005080 } /* Name.Exception.ExecutingNode */
+.codehilite .nf-ExecutingNode { color: #a6e22e; background-color: #005080 } /* Name.Function.ExecutingNode */
 .codehilite .fm { color: #a6e22e } /* Name.Function.Magic */
+.codehilite .nl-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Label.ExecutingNode */
+.codehilite .nn-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Namespace.ExecutingNode */
+.codehilite .nx-ExecutingNode { color: #a6e22e; background-color: #005080 } /* Name.Other.ExecutingNode */
+.codehilite .py-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Property.ExecutingNode */
+.codehilite .nt-ExecutingNode { color: #f92672; background-color: #005080 } /* Name.Tag.ExecutingNode */
 .codehilite .vc { color: #f8f8f2 } /* Name.Variable.Class */
+.codehilite .nv-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Variable.ExecutingNode */
 .codehilite .vg { color: #f8f8f2 } /* Name.Variable.Global */
 .codehilite .vi { color: #f8f8f2 } /* Name.Variable.Instance */
 .codehilite .vm { color: #f8f8f2 } /* Name.Variable.Magic */
+.codehilite .ow-ExecutingNode { color: #f92672; background-color: #005080 } /* Operator.Word.ExecutingNode */
+.codehilite .w-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Text.Whitespace.ExecutingNode */
+.codehilite .mb-ExecutingNode { color: #ae81ff; background-color: #005080 } /* Literal.Number.Bin.ExecutingNode */
+.codehilite .mf-ExecutingNode { color: #ae81ff; background-color: #005080 } /* Literal.Number.Float.ExecutingNode */
+.codehilite .mh-ExecutingNode { color: #ae81ff; background-color: #005080 } /* Literal.Number.Hex.ExecutingNode */
+.codehilite .mi-ExecutingNode { color: #ae81ff; background-color: #005080 } /* Literal.Number.Integer.ExecutingNode */
 .codehilite .il { color: #ae81ff } /* Literal.Number.Integer.Long */
+.codehilite .mo-ExecutingNode { color: #ae81ff; background-color: #005080 } /* Literal.Number.Oct.ExecutingNode */
+.codehilite .sa-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Affix.ExecutingNode */
+.codehilite .sb-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Backtick.ExecutingNode */
+.codehilite .sc-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Char.ExecutingNode */
+.codehilite .dl-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Delimiter.ExecutingNode */
+.codehilite .sd-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Doc.ExecutingNode */
+.codehilite .s2-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Double.ExecutingNode */
+.codehilite .se-ExecutingNode { color: #ae81ff; background-color: #005080 } /* Literal.String.Escape.ExecutingNode */
+.codehilite .sh-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Heredoc.ExecutingNode */
+.codehilite .si-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Interpol.ExecutingNode */
+.codehilite .sx-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Other.ExecutingNode */
+.codehilite .sr-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Regex.ExecutingNode */
+.codehilite .s1-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Single.ExecutingNode */
+.codehilite .ss-ExecutingNode { color: #e6db74; background-color: #005080 } /* Literal.String.Symbol.ExecutingNode */
+.codehilite .bp-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Builtin.Pseudo.ExecutingNode */
+.codehilite .fm-ExecutingNode { color: #a6e22e; background-color: #005080 } /* Name.Function.Magic.ExecutingNode */
+.codehilite .vc-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Variable.Class.ExecutingNode */
+.codehilite .vg-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Variable.Global.ExecutingNode */
+.codehilite .vi-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Variable.Instance.ExecutingNode */
+.codehilite .vm-ExecutingNode { color: #f8f8f2; background-color: #005080 } /* Name.Variable.Magic.ExecutingNode */
+.codehilite .il-ExecutingNode { color: #ae81ff; background-color: #005080 } /* Literal.Number.Integer.Long.ExecutingNode */

--- a/frontend/src/shell/Terminal.jsx
+++ b/frontend/src/shell/Terminal.jsx
@@ -163,7 +163,12 @@ export default class Terminal extends Component {
       this.props.noAutomaticStdout
     );
 
-    this.setState(toUpdate)
+    this.setState(toUpdate);
+    const input = this.terminalInput.current;
+    setTimeout(() => {
+      // Move cursor to end
+      input.selectionStart = input.selectionEnd = 10000;
+    }, 30);
   }
 
   /* istanbul ignore next: Covered by interactivity tests */

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -135,7 +135,7 @@ const RepeatedFrames = ({data}) =>
       {
         data.map((item, itemIndex) =>
         <li key={itemIndex}>
-          {`${item.name} at line ${item.lineno} - ${item.count} times`}
+          {`${item.name} at line ${item.lineno} (${item.count} times)`}
         </li>)
       }
     </ul>

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -14,7 +14,7 @@ export default class TerminalMessage extends Component {
     let {content} = this.props;
 
     if (content.isTraceback) {
-      return <Tracebacks tracebacks={content.data}/>
+      return <Tracebacks {...content}/>
     }
 
     let color = "white";
@@ -35,16 +35,23 @@ export default class TerminalMessage extends Component {
 }
 
 
-const Tracebacks = ({tracebacks}) =>
-  <div className="tracebacks-container">
-    <div className="traceback-exception">
-      <strong>Error traceback:</strong>
-    </div>
+const Tracebacks = ({tracebacks, codeSource}) => {
+  const simple = (
+    codeSource === "shell"
+    && tracebacks.length === 1
+    && tracebacks[0].frames.length === 1
+  );
+  return <div className="tracebacks-container">
+    {!simple &&
+      <div className="traceback-exception">
+        <strong>Error traceback:</strong>
+      </div>
+    }
     {
       tracebacks.map((traceback, tracebackIndex) =>
         <div className="traceback" key={tracebackIndex}>
           {
-            traceback.frames.map((frame, frameIndex) =>
+            !simple && traceback.frames.map((frame, frameIndex) =>
               frame.type === "frame" ?
                 <Frame frame={frame} key={frameIndex}/>
                 :
@@ -77,16 +84,16 @@ const Tracebacks = ({tracebacks}) =>
           </div>
           {
             traceback.didyoumean.length > 0 &&
-              <div className="traceback-didyoumean">
-                <i>Did you mean...</i>
-                <ul>
-                  {
-                    traceback.didyoumean.map((suggestion, suggestionIndex) =>
+            <div className="traceback-didyoumean">
+              <i>Did you mean...</i>
+              <ul>
+                {
+                  traceback.didyoumean.map((suggestion, suggestionIndex) =>
                     <li key={suggestionIndex}>{suggestion}?</li>
-                    )
-                  }
-                </ul>
-              </div>
+                  )
+                }
+              </ul>
+            </div>
           }
           {
             traceback.tail && <div className="traceback-tail">{traceback.tail}</div>
@@ -94,7 +101,8 @@ const Tracebacks = ({tracebacks}) =>
         </div>
       )
     }
-  </div>
+  </div>;
+}
 
 const Frame = ({frame}) =>
   <div className="traceback-frame">

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -52,6 +52,19 @@ const Tracebacks = ({tracebacks}) =>
             <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
           </div>
           {
+            traceback.didyoumean.length > 0 &&
+              <div className="traceback-didyoumean">
+                <i>Did you mean...</i>
+                <ul>
+                  {
+                    traceback.didyoumean.map((suggestion, suggestionIndex) =>
+                    <li key={suggestionIndex}>{suggestion}?</li>
+                    )
+                  }
+                </ul>
+              </div>
+          }
+          {
             traceback.tail && <div className="traceback-tail">{traceback.tail}</div>
           }
         </div>
@@ -97,8 +110,8 @@ const RepeatedFrames = ({data}) =>
     <div>Similar frames skipped:</div>
     <ul>
       {
-        data.map(item =>
-        <li>
+        data.map((item, itemIndex) =>
+        <li key={itemIndex}>
           {`${item.name} at line ${item.lineno} - ${item.count} times`}
         </li>)
       }

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -12,16 +12,19 @@ export default class TerminalMessage extends Component {
 
     if (content.isTraceback) {
       return <div className="tracebacks-container">
+        <div className="traceback-exception">
+          <strong>Error traceback:</strong>
+        </div>
         {
           content.data.map((traceback, tracebackIndex) =>
-          <div className="traceback" key={tracebackIndex}>
-            {
-              traceback.frames.map((frame, frameIndex) =>
-                <div className="traceback-frame" key={frameIndex}>
-                  <div className="traceback-frame-name">{frame.name}:</div>
-                  <table className="traceback-lines-table">
-                    <tbody>
-                    {
+              <div className="traceback" key={tracebackIndex}>
+                {
+                  traceback.frames.map((frame, frameIndex) =>
+                    <div className="traceback-frame" key={frameIndex}>
+                      <div className="traceback-frame-name">{frame.name}:</div>
+                      <table className="traceback-lines-table">
+                        <tbody>
+                        {
                       frame.lines.map(line =>
                         <tr key={line.lineno}>
                           <td className="traceback-lineno">{line.lineno}</td>

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -48,7 +48,7 @@ const Tracebacks = ({tracebacks}) =>
               frame.type === "frame" ?
                 <Frame frame={frame} key={frameIndex}/>
                 :
-                <RepeatedFrames data={frame.data}/>
+                <RepeatedFrames data={frame.data} key={frameIndex}/>
             )
           }
           <div>

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -37,8 +37,10 @@ export default class TerminalMessage extends Component {
                     {
                       frame.variables.map((variable, variableIndex) =>
                         <tr key={variableIndex}>
-                          <td className="traceback-variable-name">{variable.name}</td>
-                          <td className="traceback-variable-value">{variable.value}</td>
+                          <td className="traceback-variable-name codehilite"
+                              dangerouslySetInnerHTML={{__html: variable.name}}/>
+                          <td className="traceback-variable-value codehilite"
+                              dangerouslySetInnerHTML={{__html: variable.value}}/>
                         </tr>
                       )
                     }

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -17,45 +17,45 @@ export default class TerminalMessage extends Component {
         </div>
         {
           content.data.map((traceback, tracebackIndex) =>
-              <div className="traceback" key={tracebackIndex}>
-                {
-                  traceback.frames.map((frame, frameIndex) =>
-                    <div className="traceback-frame" key={frameIndex}>
-                      <div className="traceback-frame-name">{frame.name}:</div>
-                      <table className="traceback-lines-table">
-                        <tbody>
-                        {
-                      frame.lines.map(line =>
-                        <tr key={line.lineno}>
-                          <td className="traceback-lineno">{line.lineno}</td>
-                          <td className="traceback-line-content codehilite"
-                              dangerouslySetInnerHTML={{__html: line.content}}/>
-                        </tr>
-                      )
-                    }
-                    </tbody>
-                  </table>
-                  <table className="traceback-variables-table">
-                    <tbody>
-                    {
-                      frame.variables.map((variable, variableIndex) =>
-                        <tr key={variableIndex}>
-                          <td className="traceback-variable-name codehilite"
-                              dangerouslySetInnerHTML={{__html: variable.name}}/>
-                          <td className="traceback-variable-value codehilite"
-                              dangerouslySetInnerHTML={{__html: variable.value}}/>
-                        </tr>
-                      )
-                    }
-                    </tbody>
-                  </table>
-                </div>
-              )
-            }
-            <div className="traceback-exception">
-              <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
+            <div className="traceback" key={tracebackIndex}>
+              {
+                traceback.frames.map((frame, frameIndex) =>
+                  <div className="traceback-frame" key={frameIndex}>
+                    <div className="traceback-frame-name">{frame.name}:</div>
+                    <table className="traceback-lines-table">
+                      <tbody>
+                      {
+                        frame.lines.map(line =>
+                          <tr key={line.lineno}>
+                            <td className="traceback-lineno">{line.lineno}</td>
+                            <td className="traceback-line-content codehilite"
+                                dangerouslySetInnerHTML={{__html: line.content}}/>
+                          </tr>
+                        )
+                      }
+                      </tbody>
+                    </table>
+                    <table className="traceback-variables-table">
+                      <tbody>
+                      {
+                        frame.variables.map((variable, variableIndex) =>
+                          <tr key={variableIndex}>
+                            <td className="traceback-variable-name codehilite"
+                                dangerouslySetInnerHTML={{__html: variable.name}}/>
+                            <td className="traceback-variable-value codehilite"
+                                dangerouslySetInnerHTML={{__html: variable.value}}/>
+                          </tr>
+                        )
+                      }
+                      </tbody>
+                    </table>
+                  </div>
+                )
+              }
+              <div className="traceback-exception">
+                <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
+              </div>
             </div>
-          </div>
           )
         }
       </div>

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -21,7 +21,7 @@ export default class TerminalMessage extends Component {
               {
                 traceback.frames.map((frame, frameIndex) =>
                   <div className="traceback-frame" key={frameIndex}>
-                    <div className="traceback-frame-name">{frame.name}:</div>
+                    {frameIndex > 0 && <div className="traceback-frame-name">{frame.name}:</div>}
                     <table className="traceback-lines-table">
                       <tbody>
                       {

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -19,13 +19,26 @@ export default class TerminalMessage extends Component {
               traceback.frames.map((frame, frameIndex) =>
                 <div className="traceback-frame" key={frameIndex}>
                   <div className="traceback-frame-name">{frame.name}:</div>
-                  <table>
+                  <table className="traceback-lines-table">
                     <tbody>
                     {
                       frame.lines.map(line =>
                         <tr key={line.lineno}>
                           <td className="traceback-lineno">{line.lineno}</td>
-                          <td className="traceback-line-content codehilite" dangerouslySetInnerHTML={{__html: line.content}}/>
+                          <td className="traceback-line-content codehilite"
+                              dangerouslySetInnerHTML={{__html: line.content}}/>
+                        </tr>
+                      )
+                    }
+                    </tbody>
+                  </table>
+                  <table className="traceback-variables-table">
+                    <tbody>
+                    {
+                      frame.variables.map((variable, variableIndex) =>
+                        <tr key={variableIndex}>
+                          <td className="traceback-variable-name">{variable.name}</td>
+                          <td className="traceback-variable-value">{variable.value}</td>
                         </tr>
                       )
                     }

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -2,6 +2,9 @@ import React, {Component} from 'react'
 import AnsiUp from "ansi_up";
 
 import sourceStyles from './defs/styles/TerminalMessage'
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faInfoCircle} from "@fortawesome/free-solid-svg-icons";
+import Popup from "reactjs-popup";
 
 const ansi_up = new AnsiUp();
 
@@ -48,8 +51,28 @@ const Tracebacks = ({tracebacks}) =>
                 <RepeatedFrames data={frame.data}/>
             )
           }
-          <div className="traceback-exception">
-            <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
+          <div>
+            <span className="traceback-exception">
+              <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
+            </span>
+            {" "}
+            <Popup
+              trigger={
+                <span className="friendly-traceback-info">
+                  <FontAwesomeIcon icon={faInfoCircle}/>
+                </span>
+              }
+              position="top right"
+              on={['hover', 'focus']}
+              arrow={false}
+              contentStyle={{
+                width: "30em",
+                border: "10px solid grey"
+              }}
+            >
+              <div className="markdown-body friendly-traceback-popup"
+                   dangerouslySetInnerHTML={{__html: traceback.friendly}}/>
+            </Popup>
           </div>
           {
             traceback.didyoumean.length > 0 &&

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -55,6 +55,9 @@ export default class TerminalMessage extends Component {
               <div className="traceback-exception">
                 <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
               </div>
+              {
+                traceback.tail && <div className="traceback-tail">{traceback.tail}</div>
+              }
             </div>
           )
         }

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -9,6 +9,40 @@ export default class TerminalMessage extends Component {
 
   render() {
     let {content} = this.props;
+
+    if (content.isTraceback) {
+      return <div className="tracebacks-container">
+        {
+          content.data.map((traceback, tracebackIndex) =>
+          <div className="traceback" key={tracebackIndex}>
+            {
+              traceback.frames.map((frame, frameIndex) =>
+                <div className="traceback-frame" key={frameIndex}>
+                  <div className="traceback-frame-name">{frame.name}:</div>
+                  <table>
+                    <tbody>
+                    {
+                      frame.lines.map(line =>
+                        <tr key={line.lineno}>
+                          <td className="traceback-lineno">{line.lineno}</td>
+                          <td className="traceback-line-content codehilite" dangerouslySetInnerHTML={{__html: line.content}}/>
+                        </tr>
+                      )
+                    }
+                    </tbody>
+                  </table>
+                </div>
+              )
+            }
+            <div className="traceback-exception">
+              <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
+            </div>
+          </div>
+          )
+        }
+      </div>
+    }
+
     let color = "white";
     if (typeof content === "object") {
       color = content.color;

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -46,7 +46,7 @@ const Tracebacks = ({tracebacks}) =>
           {
             traceback.frames.map((frame, frameIndex) =>
               frame.type === "frame" ?
-                <Frame frame={frame} index={frameIndex} key={frameIndex}/>
+                <Frame frame={frame} key={frameIndex}/>
                 :
                 <RepeatedFrames data={frame.data}/>
             )
@@ -95,9 +95,9 @@ const Tracebacks = ({tracebacks}) =>
     }
   </div>
 
-const Frame = ({frame, index}) =>
+const Frame = ({frame}) =>
   <div className="traceback-frame">
-    {index > 0 && <div className="traceback-frame-name">{frame.name}:</div>}
+    {frame.name !== "<module>" && <div className="traceback-frame-name">{frame.name}:</div>}
     <table className="traceback-lines-table">
       <tbody>
       {

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -42,7 +42,10 @@ const Tracebacks = ({tracebacks}) =>
         <div className="traceback" key={tracebackIndex}>
           {
             traceback.frames.map((frame, frameIndex) =>
-              <Frame frame={frame} index={frameIndex} key={frameIndex}/>
+              frame.type === "frame" ?
+                <Frame frame={frame} index={frameIndex} key={frameIndex}/>
+                :
+                <RepeatedFrames data={frame.data}/>
             )
           }
           <div className="traceback-exception">
@@ -86,4 +89,18 @@ const Frame = ({frame, index}) =>
       }
       </tbody>
     </table>
+  </div>
+
+
+const RepeatedFrames = ({data}) =>
+  <div className="traceback-repeated-frames">
+    <div>Similar frames skipped:</div>
+    <ul>
+      {
+        data.map(item =>
+        <li>
+          {`${item.name} at line ${item.lineno} - ${item.count} times`}
+        </li>)
+      }
+    </ul>
   </div>

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -63,7 +63,7 @@ const Tracebacks = ({tracebacks, codeSource}) => {
               <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
             </span>
             {" "}
-            <Popup
+            {traceback.friendly && <Popup
               trigger={
                 <span className="friendly-traceback-info">
                   <FontAwesomeIcon icon={faInfoCircle}/>
@@ -80,7 +80,7 @@ const Tracebacks = ({tracebacks, codeSource}) => {
             >
               <div className="markdown-body friendly-traceback-popup"
                    dangerouslySetInnerHTML={{__html: traceback.friendly}}/>
-            </Popup>
+            </Popup>}
           </div>
           {
             traceback.didyoumean.length > 0 &&

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -11,57 +11,7 @@ export default class TerminalMessage extends Component {
     let {content} = this.props;
 
     if (content.isTraceback) {
-      return <div className="tracebacks-container">
-        <div className="traceback-exception">
-          <strong>Error traceback:</strong>
-        </div>
-        {
-          content.data.map((traceback, tracebackIndex) =>
-            <div className="traceback" key={tracebackIndex}>
-              {
-                traceback.frames.map((frame, frameIndex) =>
-                  <div className="traceback-frame" key={frameIndex}>
-                    {frameIndex > 0 && <div className="traceback-frame-name">{frame.name}:</div>}
-                    <table className="traceback-lines-table">
-                      <tbody>
-                      {
-                        frame.lines.map(line =>
-                          <tr key={line.lineno}>
-                            <td className="traceback-lineno">{line.lineno}</td>
-                            <td className="traceback-line-content codehilite"
-                                dangerouslySetInnerHTML={{__html: line.content}}/>
-                          </tr>
-                        )
-                      }
-                      </tbody>
-                    </table>
-                    <table className="traceback-variables-table">
-                      <tbody>
-                      {
-                        frame.variables.map((variable, variableIndex) =>
-                          <tr key={variableIndex}>
-                            <td className="traceback-variable-name codehilite"
-                                dangerouslySetInnerHTML={{__html: variable.name}}/>
-                            <td className="traceback-variable-value codehilite"
-                                dangerouslySetInnerHTML={{__html: variable.value}}/>
-                          </tr>
-                        )
-                      }
-                      </tbody>
-                    </table>
-                  </div>
-                )
-              }
-              <div className="traceback-exception">
-                <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
-              </div>
-              {
-                traceback.tail && <div className="traceback-tail">{traceback.tail}</div>
-              }
-            </div>
-          )
-        }
-      </div>
+      return <Tracebacks tracebacks={content.data}/>
     }
 
     let color = "white";
@@ -80,3 +30,60 @@ export default class TerminalMessage extends Component {
     />
   }
 }
+
+
+const Tracebacks = ({tracebacks}) =>
+  <div className="tracebacks-container">
+    <div className="traceback-exception">
+      <strong>Error traceback:</strong>
+    </div>
+    {
+      tracebacks.map((traceback, tracebackIndex) =>
+        <div className="traceback" key={tracebackIndex}>
+          {
+            traceback.frames.map((frame, frameIndex) =>
+              <Frame frame={frame} index={frameIndex} key={frameIndex}/>
+            )
+          }
+          <div className="traceback-exception">
+            <strong>{traceback.exception.type}: </strong>{traceback.exception.message}
+          </div>
+          {
+            traceback.tail && <div className="traceback-tail">{traceback.tail}</div>
+          }
+        </div>
+      )
+    }
+  </div>
+
+const Frame = ({frame, index}) =>
+  <div className="traceback-frame">
+    {index > 0 && <div className="traceback-frame-name">{frame.name}:</div>}
+    <table className="traceback-lines-table">
+      <tbody>
+      {
+        frame.lines.map(line =>
+          <tr key={line.lineno}>
+            <td className="traceback-lineno">{line.lineno}</td>
+            <td className="traceback-line-content codehilite"
+                dangerouslySetInnerHTML={{__html: line.content}}/>
+          </tr>
+        )
+      }
+      </tbody>
+    </table>
+    <table className="traceback-variables-table">
+      <tbody>
+      {
+        frame.variables.map((variable, variableIndex) =>
+          <tr key={variableIndex}>
+            <td className="traceback-variable-name codehilite"
+                dangerouslySetInnerHTML={{__html: variable.name}}/>
+            <td className="traceback-variable-value codehilite"
+                dangerouslySetInnerHTML={{__html: variable.value}}/>
+          </tr>
+        )
+      }
+      </tbody>
+    </table>
+  </div>

--- a/frontend/src/shell/TerminalMessage.jsx
+++ b/frontend/src/shell/TerminalMessage.jsx
@@ -67,7 +67,8 @@ const Tracebacks = ({tracebacks}) =>
               arrow={false}
               contentStyle={{
                 width: "30em",
-                border: "10px solid grey"
+                border: "10px solid grey",
+                zIndex: 5
               }}
             >
               <div className="markdown-body friendly-traceback-popup"

--- a/frontend/src/shell/defs/styles/Terminal.js
+++ b/frontend/src/shell/defs/styles/Terminal.js
@@ -8,7 +8,7 @@ export default {
     borderRadius: '5px',
     overflow: 'auto',
     cursor: 'text',
-    background: '#212121',
+    background: 'rgb(39, 40, 34)',
     backgroundSize: 'cover'
   },
   content: {

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,6 +22,14 @@ test = ["astroid", "pytest"]
 
 [[package]]
 category = "main"
+description = "Logic to have suggestions in case of errors (NameError, AttributeError, ImportError, TypeError, etc)."
+name = "bettererrormessages"
+optional = false
+python-versions = "*"
+version = "0.4"
+
+[[package]]
+category = "main"
 description = "Graphical Python debugger which lets you easily view the values of all evaluated expressions"
 name = "birdseye"
 optional = false
@@ -749,7 +757,7 @@ brotli = ["brotli"]
 production = ["gevent", "gunicorn", "psycopg2"]
 
 [metadata]
-content-hash = "9ef6043a507302669167edfd3860fc0e44684549f3e2154218b1e69af66321d2"
+content-hash = "f77314c8e46a13d248ff712d264989616d8eab171fe3ba0ddd7e2ca6bc4fb766"
 lock-version = "1.0"
 python-versions = "^3.8"
 
@@ -761,6 +769,10 @@ astcheck = [
 asttokens = [
     {file = "asttokens-2.0.3-py2.py3-none-any.whl", hash = "sha256:f58af645756597143629a4ac1fe78bc670b4429018ad741ac1f4cfd4504fc436"},
     {file = "asttokens-2.0.3.tar.gz", hash = "sha256:284831ac3e33be743ca6ac018316b66abfd8b1a49d6366ce6c7b1fd07504a21b"},
+]
+bettererrormessages = [
+    {file = "BetterErrorMessages-0.4-py2-none-any.whl", hash = "sha256:1ec7e7e1614668ace08811f0aeefda50317e5a3e000b50162f86590a9bcdc720"},
+    {file = "BetterErrorMessages-0.4.tar.gz", hash = "sha256:f565984d39c18bfbd5175792f9f1c0d2bf30333a66c48247e7dd9fb2d2030f70"},
 ]
 birdseye = [
     {file = "birdseye-0.8.4.tar.gz", hash = "sha256:34fbf3a042f257e981cb0d4849d279457269d212851404b19bf9635af71e0701"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -277,8 +277,12 @@ description = "Friendlier tracebacks in any language."
 name = "friendly-traceback"
 optional = false
 python-versions = ">=3.6"
-version = "0.1.1"
+version = "0.1.1a0"
 
+[package.source]
+reference = "08e88187bbf2bb9d3d21f5bea6baa2e2d64b5248"
+type = "git"
+url = "https://github.com/aroberge/friendly-traceback.git"
 [[package]]
 category = "main"
 description = "Clean single-source support for Python 3 and 2"
@@ -765,7 +769,7 @@ brotli = ["brotli"]
 production = ["gevent", "gunicorn", "psycopg2"]
 
 [metadata]
-content-hash = "1dc662b91d9d19251505150dad90480074b790b82dc440bc08fce2d530b62f8e"
+content-hash = "eef40071db7e395f8f9bf5555a92ad896e664720c30c9070c6b3c4be3d50665b"
 lock-version = "1.0"
 python-versions = "^3.8"
 
@@ -886,10 +890,7 @@ flask-humanize = [
     {file = "Flask-Humanize-0.3.0.tar.gz", hash = "sha256:f65a7b4cfcdeee1b1987f40af0f0e10f99f95423bf04e04720e7c086ea9f3d49"},
     {file = "Flask_Humanize-0.3.0-py2-none-any.whl", hash = "sha256:7beda034d191fd98db3dd1247b4ed94830d6bfbfa48d095732b158208bffa5d0"},
 ]
-friendly-traceback = [
-    {file = "friendly-traceback-0.1.1.tar.gz", hash = "sha256:4a3404f282b5016af5a6dd5a9ca4264c6d8825311daae19c851c77102466a55a"},
-    {file = "friendly_traceback-0.1.1-py3-none-any.whl", hash = "sha256:768e0783c346a39960c618bd9e5c961a79ea8107c0e503e0f7c3c8a488dc4d3f"},
-]
+friendly-traceback = []
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -273,6 +273,14 @@ humanize = ">=0.5.1"
 
 [[package]]
 category = "main"
+description = "Friendlier tracebacks in any language."
+name = "friendly-traceback"
+optional = false
+python-versions = ">=3.6"
+version = "0.1.1"
+
+[[package]]
+category = "main"
 description = "Clean single-source support for Python 3 and 2"
 name = "future"
 optional = false
@@ -757,7 +765,7 @@ brotli = ["brotli"]
 production = ["gevent", "gunicorn", "psycopg2"]
 
 [metadata]
-content-hash = "f77314c8e46a13d248ff712d264989616d8eab171fe3ba0ddd7e2ca6bc4fb766"
+content-hash = "1dc662b91d9d19251505150dad90480074b790b82dc440bc08fce2d530b62f8e"
 lock-version = "1.0"
 python-versions = "^3.8"
 
@@ -877,6 +885,10 @@ flask = [
 flask-humanize = [
     {file = "Flask-Humanize-0.3.0.tar.gz", hash = "sha256:f65a7b4cfcdeee1b1987f40af0f0e10f99f95423bf04e04720e7c086ea9f3d49"},
     {file = "Flask_Humanize-0.3.0-py2-none-any.whl", hash = "sha256:7beda034d191fd98db3dd1247b4ed94830d6bfbfa48d095732b158208bffa5d0"},
+]
+friendly-traceback = [
+    {file = "friendly-traceback-0.1.1.tar.gz", hash = "sha256:4a3404f282b5016af5a6dd5a9ca4264c6d8825311daae19c851c77102466a55a"},
+    {file = "friendly_traceback-0.1.1-py3-none-any.whl", hash = "sha256:768e0783c346a39960c618bd9e5c961a79ea8107c0e503e0f7c3c8a488dc4d3f"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -277,12 +277,8 @@ description = "Friendlier tracebacks in any language."
 name = "friendly-traceback"
 optional = false
 python-versions = ">=3.6"
-version = "0.1.1a0"
+version = "0.1.2"
 
-[package.source]
-reference = "08e88187bbf2bb9d3d21f5bea6baa2e2d64b5248"
-type = "git"
-url = "https://github.com/aroberge/friendly-traceback.git"
 [[package]]
 category = "main"
 description = "Clean single-source support for Python 3 and 2"
@@ -769,7 +765,7 @@ brotli = ["brotli"]
 production = ["gevent", "gunicorn", "psycopg2"]
 
 [metadata]
-content-hash = "eef40071db7e395f8f9bf5555a92ad896e664720c30c9070c6b3c4be3d50665b"
+content-hash = "04342041e8d69e4ca91f3045a08eb8bfb603a2921827c8aa710ec11168d199f0"
 lock-version = "1.0"
 python-versions = "^3.8"
 
@@ -890,7 +886,10 @@ flask-humanize = [
     {file = "Flask-Humanize-0.3.0.tar.gz", hash = "sha256:f65a7b4cfcdeee1b1987f40af0f0e10f99f95423bf04e04720e7c086ea9f3d49"},
     {file = "Flask_Humanize-0.3.0-py2-none-any.whl", hash = "sha256:7beda034d191fd98db3dd1247b4ed94830d6bfbfa48d095732b158208bffa5d0"},
 ]
-friendly-traceback = []
+friendly-traceback = [
+    {file = "friendly-traceback-0.1.2.tar.gz", hash = "sha256:fe975306bc3978b2e74cbabc7c12ad5c03c7c6c859e5e5e449609f0976f81df2"},
+    {file = "friendly_traceback-0.1.2-py3-none-any.whl", hash = "sha256:11a7aa52034631b431b2d0d8df20a71d3515eae01244daf7ff46f7e75fb229fa"},
+]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dryenv = "^0.0.1"
 stack_data = "^0.0.7"
 jsonfield = "^3.1.0"
 BetterErrorMessages = "^0.4"
-friendly-traceback = "^0.1.1"
+friendly-traceback = { git = "https://github.com/aroberge/friendly-traceback.git", rev = "08e88187" }
 
 [tool.poetry.extras]
 production = ["gevent", "gunicorn", "psycopg2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dryenv = "^0.0.1"
 stack_data = "^0.0.7"
 jsonfield = "^3.1.0"
 BetterErrorMessages = "^0.4"
+friendly-traceback = "^0.1.1"
 
 [tool.poetry.extras]
 production = ["gevent", "gunicorn", "psycopg2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ psutil = "^5.7.0"
 dryenv = "^0.0.1"
 stack_data = "^0.0.7"
 jsonfield = "^3.1.0"
+BetterErrorMessages = "^0.4"
 
 [tool.poetry.extras]
 production = ["gevent", "gunicorn", "psycopg2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dryenv = "^0.0.1"
 stack_data = "^0.0.7"
 jsonfield = "^3.1.0"
 BetterErrorMessages = "^0.4"
-friendly-traceback = { git = "https://github.com/aroberge/friendly-traceback.git", rev = "08e88187" }
+friendly-traceback = "^0.1.2"
 
 [tool.poetry.extras]
 production = ["gevent", "gunicorn", "psycopg2"]


### PR DESCRIPTION
This closes #75 and overhauls tracebacks to be much more helpful, beginner friendly, and nice to look at.

Here is an example script which demonstrates most of the functionality:

```python
def print_many(n, thing):
    for _ in range(n):
        print(thing)
        try:
            foo()
        except:
            thong

def foo():
    return foo()

def print_twice(x):
    print_many(
        2,
        x,
    )


print_twice("Hello")
```

Main features:

- Values of variables in a table in each frame
- Explanations of errors using https://github.com/aroberge/friendly-traceback - hover over the 'i' icon next to an exception message to see.
- Suggestions for fixes from https://github.com/SylvainDe/DidYouMean-Python
- Highlighting of the executing node in blue (although that was already there before)
- Handling of exception chains, e.g. "During handling of the above exception, another exception occurred:"
- Handling of chains of similar frames in recursion errors, i.e. "Similar frames skipped:"

Lots of small decisions made in the design:

- Start with "Error traceback:" rather than "Traceback (most recent call last):". The former makes it clear that this is an error while still introducing people to the jargon 'traceback'. The latter is less clear to beginners. The information 'most recent call last' is more noisy than helpful.
- Each frame is outlined because that matches the word 'frame' nicely and implies an isolated scope.
- The line numbers are styled just like the editor above to indicate that users are looking at a sample of their code.
- Frames not belonging to the user's program are hidden. Showing code from e.g. the standard library would not be very useful to a beginner.
- The header of each frame contains only the name of the current function (or other code object). There's no need for the filename since only the user's 'file' is shown, and the line number is already on the side.
- The header is omitted when it would be `<module>` as this is not meaningful to beginners and doesn't really add much information anyway.
- Extra lines of code for context are not added as in some other tracebacks (e.g. python) since users just wrote this exact code and can see it right above so it doesn't add much value. However stack_data ensures that multiline expressions are shown in full.
- A bit of red text makes it clear this is an error, but it's not all in red to not scare the user.
- Exception message is in slightly larger text for emphasis, with the type in bold, since this is what the user needs to look at the most.
- An exception in the shell and not in a deeper function call only shows the exception message (and maybe suggestions). Showing the frame would be pointless.
- Syntax errors are treated differently. The explanation from friendly traceback is shown immediately (rather than in an icon that needs hovering) because the user probably needs to look at it more so than a runtime error, and there's not much else to see anyway.

Also threw in some other random little fixes not worth their own PR. In particular this closes #39 