### PR TITLE
Fixes generate_board function to support non-winning state

### DIFF
--- a/core/chapters/c11_tic_tac_toe_project.py
+++ b/core/chapters/c11_tic_tac_toe_project.py
@@ -36,6 +36,13 @@ def generate_board(board_type):
                     board[i][i] = winning_piece
                 else:
                     board[i][-i - 1] = winning_piece
+    else:
+        diag = choice([True, False])
+        for i in range(size):
+            if diag:
+                board[i][i] = ' '
+            else:
+                board[i][-i - 1] = ' '
     return board
 
 


### PR DESCRIPTION
In Chapter 11, `generate_board()` creates a random board which is then used in test cases. The problem is, when `winning` evaluates to `False` the random board is assumed to be not-winning, but in rare cases can still contain winning lines.

To address this, I've added an `else` case to write blank values into either of the two diagonals. This prevents the board from containing a winning line and the function can now be used to safely generate non-winning test cases.