### PR TITLE
Fixes generate_board for even sized grids

### DIFF
--- a/core/chapters/c11_tic_tac_toe_project.py
+++ b/core/chapters/c11_tic_tac_toe_project.py
@@ -43,6 +43,11 @@ def generate_board(board_type):
                 board[i][i] = ' '
             else:
                 board[i][-i - 1] = ' '
+        if (size % 2) == 0:
+            if diag:
+                board[0][-1] = ' '
+            else:
+                board[0][0] = ' '
     return board
 
 


### PR DESCRIPTION
Even sized grids don't share a middle field, so we have to insert another empty field somewhere along the other diagonal. For simplicity’s sake, I just went with the top left/right corner.