### PR TITLE
Adding page metadata for futurecoder - fixes #204

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -11,10 +11,10 @@
             name="description"
             content="Learn to code from scratch for free"
     />
-    <meta property="og:title" content="futurecoder: learn python from scratch"/>
+    <meta property="og:title" content="futurecoder: Learn to code from scratch"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:description" content="Learn to code from scratch for free"/>
-    <meta property="og:image" content="https://futurecoder.io/static/logo/favicon_large.png"/>
+    <meta property="og:description" content="100% free and interactive Python course for beginners"/>
+    <meta property="og:image" content="https://futurecoder.io/static/logo/bordered.png"/>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -11,6 +11,10 @@
             name="description"
             content="Learn to code from scratch for free"
     />
+    <meta property="og:title" content="futurecoder: learn python from scratch"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:description" content="Learn to code from scratch for free"/>
+    <meta property="og:image" content="https://futurecoder.io/static/logo/favicon_large.png"/>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -12,10 +12,10 @@
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css">
     <link rel="shortcut icon" type="image/png" href="static/logo/favicon_32px.png"/>
-    <meta property="og:title" content="futurecoder: learn python from scratch"/>
+    <meta property="og:title" content="futurecoder: Learn to code from scratch"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:description" content="Learn to code from scratch for free"/>
-    <meta property="og:image" content="https://futurecoder.io/static/logo/favicon_large.png"/>
+    <meta property="og:description" content="100% free and interactive Python course for beginners"/>
+    <meta property="og:image" content="https://futurecoder.io/static/logo/bordered.png"/>
 </head>
 <body onload="AOS.init({once:true})">
 <div class="body-wrap boxed-container home-page">

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -12,6 +12,10 @@
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css">
     <link rel="shortcut icon" type="image/png" href="static/logo/favicon_32px.png"/>
+    <meta property="og:title" content="futurecoder: learn python from scratch"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:description" content="Learn to code from scratch for free"/>
+    <meta property="og:image" content="https://futurecoder.io/static/logo/favicon_large.png"/>
 </head>
 <body onload="AOS.init({once:true})">
 <div class="body-wrap boxed-container home-page">


### PR DESCRIPTION
fixes #204 

Icon used is favicon_large.png
Description copied from frontent/public/index.html

Tested using: https://local-ogp.firebaseapp.com/

<img width="1006" alt="Screenshot 2021-11-03 at 10 11 16 PM" src="https://user-images.githubusercontent.com/2451152/140104952-e1c951bf-180e-4bf0-8f4d-e111edd0b0e4.png">
