### PR TITLE
Added display for num of hints. Fixed bug for resetting hint count.

### DIFF
--- a/frontend/src/Hints.js
+++ b/frontend/src/Hints.js
@@ -40,7 +40,7 @@ export const HintsPopup = ({hints, numHints, requestingSolution, solution}) => {
 const Hints = ({hints, numHints, requestingSolution, solution}) =>
   <div className="markdown-body">
     {hints.slice(0, numHints).map((hint, index) =>
-      <div className="hint-body">
+      <div className="hint-body" key={index}>
         <div key={index} dangerouslySetInnerHTML={{__html: hint}}/>
         <hr/>
       </div>
@@ -58,6 +58,7 @@ const Hints = ({hints, numHints, requestingSolution, solution}) =>
           />
       }
     </div>
+    <span className="float-right">Shown {numHints} of {hints.length} hint(s).</span>
   </div>
 
 

--- a/frontend/src/book/store.js
+++ b/frontend/src/book/store.js
@@ -145,7 +145,6 @@ export const moveStep = (delta) => {
     animateStep(stepIndex);
   }
   setUserStateAndDatabase(["pagesProgress", localState.user.pageSlug, "step_name"], step.name);
-  resetHintCount();
 };
 
 const animateStep = (stepIndex) => {
@@ -285,16 +284,6 @@ const loadUserAndPages = (state, previousUser = {}) => {
   }
   return state;
 }
-
-export const resetHintCount = makeAction(
-  'RESET_HINTS',
-  (state) => {
-    return {
-      ...state,
-      numHints: 0,
-    };
-  },
-);
 
 export const showHint = makeAction(
   'SHOW_HINT',

--- a/frontend/src/book/store.js
+++ b/frontend/src/book/store.js
@@ -145,6 +145,7 @@ export const moveStep = (delta) => {
     animateStep(stepIndex);
   }
   setUserStateAndDatabase(["pagesProgress", localState.user.pageSlug, "step_name"], step.name);
+  resetHintCount();
 };
 
 const animateStep = (stepIndex) => {
@@ -284,6 +285,16 @@ const loadUserAndPages = (state, previousUser = {}) => {
   }
   return state;
 }
+
+export const resetHintCount = makeAction(
+  'RESET_HINTS',
+  (state) => {
+    return {
+      ...state,
+      numHints: 0,
+    };
+  },
+);
 
 export const showHint = makeAction(
   'SHOW_HINT',


### PR DESCRIPTION
Regarding #219.

Hint popup should now show current hint you're on as well as number of total hints for the current step.

I've also found a bug that hints would not reset when moving through steps, so if you used 8 / 8 hints and then moved onto the next step that had 10 hints, 8 out of 10 hints would already be revealed. This should fix that bug as well.