### PR TITLE
[experimental] Wrap firebase/googleapis calls with try/catch

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -438,7 +438,11 @@ const MenuPopup = ({user}) =>
             onClick={() => {
               close();
               bookSetState("user.uid", null)
-              firebase.auth().signOut();
+              try {
+                firebase.auth().signOut().catch(console.warn);
+              } catch (err) {
+                console.warn(err)
+              }
             }}
           >
             <FontAwesomeIcon icon={faSignOutAlt}/> {terms.sign_out}

--- a/frontend/src/components/HeaderLoginInfo.jsx
+++ b/frontend/src/components/HeaderLoginInfo.jsx
@@ -1,71 +1,71 @@
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {faUser} from '@fortawesome/free-solid-svg-icons';
-import {ErrorBoundary} from '@sentry/react';
-import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
-import firebase from 'firebase';
-import {updateDatabase, updateUserData} from '../book/store';
-import Popup from 'reactjs-popup';
-import * as terms from '../terms.json';
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faUser} from "@fortawesome/free-solid-svg-icons";
+import StyledFirebaseAuth from "react-firebaseui/StyledFirebaseAuth";
+import firebase from "firebase";
+import {updateDatabase, updateUserData} from "../book/store";
+import Popup from "reactjs-popup";
+import * as terms from "../terms.json"
 
-const HeaderLoginInfo = ({email}) => {
+const HeaderLoginInfo = ({ email }) => {
   return email ?
-         <><FontAwesomeIcon icon={faUser}/> {email}</> :
-         <Popup
-           trigger={
-             <button className="btn btn-primary">
-               <FontAwesomeIcon icon={faUser}/> {terms.login_or_sign_up}
-             </button>
-           }
-           modal
-           closeOnDocumentClick
-         >
-           {close =>
-             <StyledFirebaseAuth
-               uiConfig={{
-                 signInOptions            : [
-                   {
-                     provider          : firebase.auth.EmailAuthProvider.PROVIDER_ID,
-                     requireDisplayName: false,
-                   },
-                   // TODO not working because of cross origin isolation
-                   // firebase.auth.GoogleAuthProvider.PROVIDER_ID,
-                   // firebase.auth.FacebookAuthProvider.PROVIDER_ID,
-                   // firebase.auth.GithubAuthProvider.PROVIDER_ID,
-                 ],
-                 autoUpgradeAnonymousUsers: true,
-                 callbacks                : {
-                   // Avoid redirects after sign-in.
-                   signInSuccessWithAuthResult: async (authResult) => {
-                     // Popup must be closed before updating user data to avoid memory leaks
-                     close();
-                     if (authResult.user) {
-                       await updateUserData(authResult.user);
-                     }
-                     return false;
-                   },
+    <><FontAwesomeIcon icon={faUser}/> {email}</> :
+    <Popup
+      trigger={
+      <button className="btn btn-primary">
+        <FontAwesomeIcon icon={faUser}/> {terms.login_or_sign_up}
+      </button>
+    }
+    modal
+    closeOnDocumentClick
+  >
+    {close =>
+      <StyledFirebaseAuth
+        uiConfig={{
+          signInOptions: [
+            {
+              provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
+              requireDisplayName: false,
+            },
+            // TODO not working because of cross origin isolation
+            // firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+            // firebase.auth.FacebookAuthProvider.PROVIDER_ID,
+            // firebase.auth.GithubAuthProvider.PROVIDER_ID,
+          ],
+          autoUpgradeAnonymousUsers: true,
+          callbacks: {
+            // Avoid redirects after sign-in.
+            signInSuccessWithAuthResult: async (authResult) => {
+              // Popup must be closed before updating user data to avoid memory leaks
+              close();
+              if (authResult.user) {
+                await updateUserData(authResult.user);
+              }
+              return false;
+            },
 
-                   // Ignore merge conflicts when upgrading anonymous users and continue signing in
-                   // The store will merge the user data
-                   signInFailure: async (error) => {
-                     if (error.code === 'firebaseui/anonymous-upgrade-merge-conflict') {
-                       // Note the upgrade in the old anonymous account
-                       await updateDatabase({upgradedFromAnonymous: true});
+            // Ignore merge conflicts when upgrading anonymous users and continue signing in
+            // The store will merge the user data
+            signInFailure: async (error) => {
+              if (error.code === 'firebaseui/anonymous-upgrade-merge-conflict') {
+                // Note the upgrade in the old anonymous account
+                await updateDatabase({upgradedFromAnonymous: true});
 
-                       try {
-                         await firebase.auth().signInWithCredential(error.credential);
-                       } catch (err) {
-                         console.warn(err);
-                       }
-                       close();
-                     }
-                   },
-                 },
-               }}
-               firebaseAuth={getFirebaseAuth()}
-             />
-           }
-         </Popup>;
-};
+                try {
+                  await firebase.auth().signInWithCredential(error.credential);
+                } catch (err) {
+                  console.warn(err);
+                }
+                close();
+              }
+            }
+          }
+        }}
+        firebaseAuth={getFirebaseAuth()}
+      />
+    }
+  </Popup>
+}
+
 
 function getFirebaseAuth() {
   try {

--- a/frontend/src/components/HeaderLoginInfo.jsx
+++ b/frontend/src/components/HeaderLoginInfo.jsx
@@ -1,65 +1,78 @@
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faUser} from "@fortawesome/free-solid-svg-icons";
-import StyledFirebaseAuth from "react-firebaseui/StyledFirebaseAuth";
-import firebase from "firebase";
-import {updateDatabase, updateUserData} from "../book/store";
-import Popup from "reactjs-popup";
-import * as terms from "../terms.json"
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faUser} from '@fortawesome/free-solid-svg-icons';
+import {ErrorBoundary} from '@sentry/react';
+import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
+import firebase from 'firebase';
+import {updateDatabase, updateUserData} from '../book/store';
+import Popup from 'reactjs-popup';
+import * as terms from '../terms.json';
 
-const HeaderLoginInfo = ({ email }) => {
+const HeaderLoginInfo = ({email}) => {
   return email ?
-    <><FontAwesomeIcon icon={faUser}/> {email}</> :
-    <Popup
-      trigger={
-      <button className="btn btn-primary">
-        <FontAwesomeIcon icon={faUser}/> {terms.login_or_sign_up}
-      </button>
-    }
-    modal
-    closeOnDocumentClick
-  >
-    {close =>
-      <StyledFirebaseAuth
-        uiConfig={{
-          signInOptions: [
-            {
-              provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
-              requireDisplayName: false,
-            },
-            // TODO not working because of cross origin isolation
-            // firebase.auth.GoogleAuthProvider.PROVIDER_ID,
-            // firebase.auth.FacebookAuthProvider.PROVIDER_ID,
-            // firebase.auth.GithubAuthProvider.PROVIDER_ID,
-          ],
-          autoUpgradeAnonymousUsers: true,
-          callbacks: {
-            // Avoid redirects after sign-in.
-            signInSuccessWithAuthResult: async (authResult) => {
-              // Popup must be closed before updating user data to avoid memory leaks
-              close();
-              if (authResult.user) {
-                await updateUserData(authResult.user);
-              }
-              return false;
-            },
+         <><FontAwesomeIcon icon={faUser}/> {email}</> :
+         <Popup
+           trigger={
+             <button className="btn btn-primary">
+               <FontAwesomeIcon icon={faUser}/> {terms.login_or_sign_up}
+             </button>
+           }
+           modal
+           closeOnDocumentClick
+         >
+           {close =>
+             <StyledFirebaseAuth
+               uiConfig={{
+                 signInOptions            : [
+                   {
+                     provider          : firebase.auth.EmailAuthProvider.PROVIDER_ID,
+                     requireDisplayName: false,
+                   },
+                   // TODO not working because of cross origin isolation
+                   // firebase.auth.GoogleAuthProvider.PROVIDER_ID,
+                   // firebase.auth.FacebookAuthProvider.PROVIDER_ID,
+                   // firebase.auth.GithubAuthProvider.PROVIDER_ID,
+                 ],
+                 autoUpgradeAnonymousUsers: true,
+                 callbacks                : {
+                   // Avoid redirects after sign-in.
+                   signInSuccessWithAuthResult: async (authResult) => {
+                     // Popup must be closed before updating user data to avoid memory leaks
+                     close();
+                     if (authResult.user) {
+                       await updateUserData(authResult.user);
+                     }
+                     return false;
+                   },
 
-            // Ignore merge conflicts when upgrading anonymous users and continue signing in
-            // The store will merge the user data
-            signInFailure: async (error) => {
-              if (error.code === 'firebaseui/anonymous-upgrade-merge-conflict') {
-                // Note the upgrade in the old anonymous account
-                await updateDatabase({upgradedFromAnonymous: true});
+                   // Ignore merge conflicts when upgrading anonymous users and continue signing in
+                   // The store will merge the user data
+                   signInFailure: async (error) => {
+                     if (error.code === 'firebaseui/anonymous-upgrade-merge-conflict') {
+                       // Note the upgrade in the old anonymous account
+                       await updateDatabase({upgradedFromAnonymous: true});
 
-                await firebase.auth().signInWithCredential(error.credential);
-                close();
-              }
-            }
-          }
-        }}
-        firebaseAuth={firebase.auth()}
-      />
-    }
-  </Popup>
+                       try {
+                         await firebase.auth().signInWithCredential(error.credential);
+                       } catch (err) {
+                         console.warn(err);
+                       }
+                       close();
+                     }
+                   },
+                 },
+               }}
+               firebaseAuth={getFirebaseAuth()}
+             />
+           }
+         </Popup>;
+};
+
+function getFirebaseAuth() {
+  try {
+    return firebase.auth();
+  } catch (err) {
+    console.warn(err);
+  }
 }
 
 export default HeaderLoginInfo;

--- a/homepage/static/js/main.js
+++ b/homepage/static/js/main.js
@@ -79,10 +79,14 @@
 }())
 
 function submitEmailGeneric(email, key) {
-  fetch(`https://futurecoder-io-default-rtdb.firebaseio.com/${key}.json`, {
-    method: "POST",
-    body: JSON.stringify({email, timestamp: new Date().toISOString()}),
-  });
+  try {
+    fetch(`https://futurecoder-io-default-rtdb.firebaseio.com/${key}.json`, {
+      method: "POST",
+      body: JSON.stringify({email, timestamp: new Date().toISOString()}),
+    }).catch(console.warn);
+  } catch (err) {
+    console.warn(err)
+  }
 }
 
 function submitEmail() {


### PR DESCRIPTION
While I was testing, something caused an infinite redirect to happen, which caused a lot of calls to Firebase, then Firebase temporarily blocked my browser. So, I figured I'd try wrapping the Firebase stuff in try/catch; it might help with issue #163.

With these changes, the course works (and code runs) without access to `firebaseio.com` — tested by blocking network requests to that domain. It still breaks once I block `googleapis.com`, **but,** it's not erroring-out. It's just staying on "Loading..." because `isLoaded` depends on `state.user.uid`. I'm guessing that there's a way to refactor such that `isLoaded` can know it's loaded without depending on `state.user.uid` — or perhaps dummy info could be put into `state.user` when auth stuff fails.