### PR TITLE
Just the logo

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,20 +25,10 @@ jobs:
         REACT_APP_FIREBASE_STAGING: '1'
         FUTURECODER_LANGUAGE: en
       run: ./scripts/build.sh
-    - name: Saucelabs tunnel
-      uses: saucelabs/sauce-connect-action@v2
-      with:
-          username: ${{ secrets.SAUCE_USERNAME }}
-          accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-          tunnelName: github-action-tunnel
-          region: eu-central
     - name: Test
       env:
         FUTURECODER_LANGUAGE: en
         FIREBASE_TOKEN: '1//03I37hFeN4kn3CgYIARAAGAMSNwF-L9IrUvqofZbhOkS8YMtQBhw_bu2TpWYC5MHvnaZDsWPP0KJMypXPyoxogkl8A6p2RxPJQwQ'
-        SAUCE_TUNNEL: github-action-tunnel
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       run: ./scripts/ci_test.sh
     - name: Upload test artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -194,7 +194,7 @@
                                 GitHub
                             </div>
                             <div class="flex">
-                                <span><i class="fa fa-star"></i> 770</span>
+                                <span><i class="fa fa-star"></i> 1000+</span>
                             </div>
                         </a>
                     </div>

--- a/scripts/ci_test.sh
+++ b/scripts/ci_test.sh
@@ -4,5 +4,7 @@ set -eux
 
 # Run tests in CI, i.e. GitHub Actions
 
+export DISPLAY=:99
+chromedriver --url-base=/wd/hub &
 npm install -g firebase-tools
 firebase emulators:exec "poetry run pytest tests"

--- a/translations/locales/fr/index.html
+++ b/translations/locales/fr/index.html
@@ -250,7 +250,7 @@
                                     GitHub
                                 </div>
                                 <div class="flex">
-                                    <span><i class="fa fa-star"></i> 770</span>
+                                    <span><i class="fa fa-star"></i> 1000+</span>
                                 </div>
                             </a>
                         </div>

--- a/translations/locales/ta/index.html
+++ b/translations/locales/ta/index.html
@@ -198,7 +198,7 @@
                                 GitHub
                             </div>
                             <div class="flex">
-                                <span><i class="fa fa-star"></i> 770</span>
+                                <span><i class="fa fa-star"></i> 1000+</span>
                             </div>
                         </a>
                     </div>


### PR DESCRIPTION
The futurecoder frontend tests are already too slow, testing 'remotely' makes them even slower. They also don't work reliably across platforms on saucelabs. The open source license/account is still useful for dependencies like https://github.com/alexmojaki/pyodide-worker-runner/ where testing is simpler, so we keep the logo in the README.