### PR TITLE
Ruff fixes

### DIFF
--- a/core/chapters/c01_the_shell.py
+++ b/core/chapters/c01_the_shell.py
@@ -1,6 +1,5 @@
 # flake8: NOQA E501
 import ast
-from textwrap import dedent
 
 from core.text import MessageStep, Page, Step, VerbatimStep, search_ast
 

--- a/core/chapters/c04_for_loops.py
+++ b/core/chapters/c04_for_loops.py
@@ -16,7 +16,8 @@ __program_indented__
 
         def program(self):
             name = 'World'
-            for character in name: print(character)
+            for character in name:
+                print(character)
 
     final_text = """
 You can read the code almost like normal English:

--- a/core/chapters/c04_for_loops.py
+++ b/core/chapters/c04_for_loops.py
@@ -16,8 +16,7 @@ __program_indented__
 
         def program(self):
             name = 'World'
-            for character in name:
-                print(character)
+            for character in name: print(character)
 
     final_text = """
 You can read the code almost like normal English:

--- a/core/chapters/c05_if_statements.py
+++ b/core/chapters/c05_if_statements.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 
 import pure_eval
 
-from core.text import ExerciseStep, Page, Step, VerbatimStep, search_ast, Disallowed
+from core.text import ExerciseStep, Page, Step, VerbatimStep, Disallowed
 
 
 class IntroducingIfStatements(Page):

--- a/core/chapters/c12_dictionaries.py
+++ b/core/chapters/c12_dictionaries.py
@@ -652,7 +652,7 @@ Beautiful! There's a pattern emerging here. The two languages could be merged in
                     print(f"English: {word}")
                     for language in translations:
                         print(f"{language}: {translations[language]}")
-                    print(f"---")
+                    print("---")
 
             print_words({
                 'apple': {

--- a/core/question_wizard.py
+++ b/core/question_wizard.py
@@ -23,7 +23,7 @@ def input_messages(input_nodes):
             if len(multi_nodes) > 1:
                 list_name = f"test_inputs_{multi_nodes.index(node) + 1}"
             else:
-                list_name = f"test_inputs"
+                list_name = "test_inputs"
             list_line = f"{list_name} = {list(strings)}"
             replacement_text = f"{list_name}.pop(0)"
         else:

--- a/core/text.py
+++ b/core/text.py
@@ -8,11 +8,9 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from functools import cached_property, cache
 from importlib import import_module
-from io import StringIO
 from pathlib import Path
 from random import shuffle
 from textwrap import indent
-from tokenize import Untokenizer, generate_tokens
 from types import MethodType
 from typing import Union, List, get_type_hints
 
@@ -239,7 +237,7 @@ def get_predictions(cls):
 
     answer = cls.correct_output
     choices = [t.get(t.prediction_choice(cls, i), choice.rstrip()).rstrip() for i, choice in enumerate(choices)]
-    error = t.get(f"output_predictions.Error", "Error")
+    error = t.get("output_predictions.Error", "Error")
 
     if answer:
         assert answer == "Error"

--- a/scripts/generate_static_files.py
+++ b/scripts/generate_static_files.py
@@ -137,7 +137,7 @@ def main():
         if t.current_language not in (None, "en"):
             for arcname in [
                 f"translations/locales/{t.current_language}/LC_MESSAGES",
-                f"translations/codes.json",
+                "translations/codes.json",
             ]:
                 tar.add(core_dir.parent / arcname, arcname=arcname, recursive=True, filter=tarfile_filter)
             arcname = f"friendly_traceback/locales/{t.current_language}/LC_MESSAGES/friendly_tb_{t.current_language}.mo"

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -4,7 +4,6 @@ import random
 import re
 from pathlib import Path
 
-from littleutils import only
 
 import core.utils
 from core import translation as t

--- a/translations/english.po
+++ b/translations/english.po
@@ -2096,7 +2096,7 @@ msgstr "'Dylan'"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -2120,7 +2120,7 @@ msgstr "'French'"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -3206,7 +3206,7 @@ msgstr "'aeiou'"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -3301,7 +3301,7 @@ msgstr "'apfel'"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -3438,7 +3438,7 @@ msgstr "'bc'"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -3509,7 +3509,7 @@ msgstr "'boite'"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -4123,7 +4123,7 @@ msgstr "'jklmn'"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -4250,7 +4250,7 @@ msgstr "'on'"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -8925,7 +8925,7 @@ msgstr "expected"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -8955,7 +8955,7 @@ msgstr "f\"2 * 3 + 4 is equal to {2 * 3 + 4}\""
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -9059,7 +9059,7 @@ msgstr "f\"There are {len(people)} people waiting, the first one's name is {peop
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -11101,7 +11101,7 @@ msgstr "key"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -15196,7 +15196,7 @@ msgstr "print_winner"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -18443,7 +18443,7 @@ msgstr "total_cost"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -19086,7 +19086,7 @@ msgstr "winning_line"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {
@@ -19335,7 +19335,7 @@ msgstr "word"
 #.         print(f"English: {word}")
 #.         for language in translations:
 #.             print(f"{language}: {translations[language]}")
-#.         print(f"---")
+#.         print("---")
 #. 
 #. print_words({
 #.     'apple': {

--- a/translations/generate_po_file.py
+++ b/translations/generate_po_file.py
@@ -152,7 +152,7 @@ def text_entry(msgid, text, comments=()):
             code_bits[node_text].add(f"{search_link(msgid)}\n\n{code_text}")
             comments.add(search_link(t.code_bit(node_text)))
 
-    assert f" __code" not in text
+    assert " __code" not in text
     comment = "\n\n".join([page_link, *code_comments, *sorted(comments)])
     entry(msgid, text, comment)
 

--- a/videos/scenes.py
+++ b/videos/scenes.py
@@ -1,4 +1,22 @@
-from manim import *
+from manim import (
+    DOWN,
+    LEFT,
+    ORIGIN,
+    RIGHT,
+    UP,
+    AnimationGroup,
+    ApplyMethod,
+    BulletedList,
+    FadeInFrom,
+    LaggedStart,
+    Line,
+    PangoText,
+    Scene,
+    ShowCreation,
+    VGroup,
+    Write,
+    config,
+)
 
 Text = PangoText
 


### PR DESCRIPTION
https://docs.astral.sh/ruff is the modern linter and formatter for Python code.

This pull request applies a few [lint rules](https://docs.astral.sh/ruff/rules/) to help teach good practices to new coders.

% `ruff --statistics`
```
42	F405	[ ] `AnimationGroup` may be undefined, or defined from star imports
 6	F401	[*] `core.text.search_ast` imported but unused
 5	F541	[*] f-string without any placeholders
 2	E402	[ ] Module level import not at top of file
 2	F841	[*] Local variable `french` is assigned to but never used
 1	E701	[ ] Multiple statements on one line (colon)
 1	F403	[ ] `from manim import *` used; unable to detect undefined names
```
% `ruff rule F401`
# unused-import (F401)

Derived from the **Pyflakes** linter.

Fix is sometimes available.

## What it does
Checks for unused imports.

## Why is this bad?
Unused imports add a performance overhead at runtime, and risk creating
import cycles. They also increase the cognitive load of reading the code.

If an import statement is used to check for the availability or existence
of a module, consider using `importlib.util.find_spec` instead.

If an import statement is used to re-export a symbol as part of a module's
public interface, consider using a "redundant" import alias, which
instructs Ruff (and other tools) to respect the re-export, and avoid
marking it as unused, as in:

```python
from module import member as member
```

## Example
```python
import numpy as np  # unused import


def area(radius):
    return 3.14 * radius**2
```

Use instead:
```python
def area(radius):
    return 3.14 * radius**2
```

To check the availability of a module, use `importlib.util.find_spec`:
```python
from importlib.util import find_spec

if find_spec("numpy") is not None:
    print("numpy is installed")
else:
    print("numpy is not installed")
```

## Options
- `lint.ignore-init-module-imports`

## References
- [Python documentation: `import`](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement)
- [Python documentation: `importlib.util.find_spec`](https://docs.python.org/3/library/importlib.html#importlib.util.find_spec)
- [Typing documentation: interface conventions](https://typing.readthedocs.io/en/latest/source/libraries.html#library-interface-public-and-private-symbols)