### PR TITLE
Fix 470: editor shows all lines in fullscreen mode by using ResizeObserver to trigger Ace layout recalculation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -160,28 +160,46 @@ const EditorButtons = (
       </a>}
   </div>;
 
-const Editor = ({readOnly, value}) =>
-  <div className="editor">
-    <AceEditor
-      mode="python"
-      theme="monokai"
-      onChange={setEditorContent}
-      onLoad={(editor) => {
-        editor.renderer.setScrollMargin(10);
-        editor.renderer.setPadding(10);
-      }}
-      value={value}
-      name="editor"
-      height="100%"
-      width="100%"
-      fontSize="15px"
-      setOptions={{
-        fontFamily: "monospace",
-        showPrintMargin: false,
-      }}
-      readOnly={readOnly}
-    />
-  </div>;
+const Editor = ({readOnly, value}) => {
+  const editorRef = React.useRef(null);
+  const containerRef = React.useRef(null);
+  React.useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    // ResizeObserver calls editor.resize() whenever the container size changes
+    const observer = new ResizeObserver(() => {
+      if (editorRef.current) {
+        editorRef.current.resize();
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+  return (
+    <div className="editor" ref={containerRef}>
+      <AceEditor
+        mode="python"
+        theme="monokai"
+        onChange={setEditorContent}
+        onLoad={(editor) => {
+          editorRef.current = editor;
+          editor.renderer.setScrollMargin(10);
+          editor.renderer.setPadding(10);
+        }}
+        value={value}
+        name="editor"
+        height="100%"
+        width="100%"
+        fontSize="15px"
+        setOptions={{
+          fontFamily: "monospace",
+          showPrintMargin: false,
+        }}
+        readOnly={readOnly}
+      />
+    </div>
+  );
+};
 
 const Shell = () =>
   <Terminal
@@ -526,7 +544,7 @@ function AppMain(
     <div className={`ide ide-${fullIde ? 'full' : 'half'}`}>
       <div className="editor-and-terminal">
         {showEditor &&
-          <Editor key={fullIde ? 'full' : 'half'} value={editorContent} readOnly={cantUseEditor}/> 
+          <Editor value={editorContent} readOnly={cantUseEditor}/> 
         }
         <div className="terminal" style={{height: showEditor ? undefined : "100%"}}>
           <Shell/>


### PR DESCRIPTION
**Problem**
In fullscreen mode, the Ace editor only displayed roughly half the lines, the bottom portion of the editor was blank and unscrollable. 
**Cause**
This happened because Ace only measures container size once on mount and doesn't recalculate on layout changes between .ide-half and .ide-full. 

**First approach**
Force a remount using key={fullIde ? 'full' : 'half'} on the Editor component. This worked but remounting the component would cause cursor position, text selection and undo history to be lost on every fullscreen toggle.
**Second and final solution**
Use a ResizeObserver on the editor container to call editor.resize() whenever its size changes. This fixes the fullscreen bug while preserving cursor position, selection, and undo history.

**Changes**
Added containerRef and editorRef to the Editor component
Added a useEffect that sets up a ResizeObserver on the container
When the container resizes, editor.resize() is called so Ace recalculates its layout

I'm open to any feedback @alexmojaki 